### PR TITLE
limit the endpoints to measure response times for

### DIFF
--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -12,7 +12,6 @@ export const handleResponseTime = (
 	return responseTime((req: Request, res: Response, time: number) => {
 		const endpoint = req.path;
 
-		console.log(endpoint);
 		if (!measuredEndpoints.includes(endpoint)) {
 			return;
 		}

--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -4,14 +4,21 @@ import {
 	endpointResponseTimeHistogram,
 	responseStatusCounter,
 } from './metrics';
+import { MEASURED_ENDPOINTS } from '../utils/constants';
 
-export const handleResponseTime = responseTime(
-	(req: Request, res: Response, time: number) => {
+export const handleResponseTime = (
+	measuredEndpoints: string[] = MEASURED_ENDPOINTS
+) => {
+	return responseTime((req: Request, res: Response, time: number) => {
 		const endpoint = req.path;
 
-		if (endpoint === '/health' || req.url === '/') {
+		console.log(endpoint);
+		if (!measuredEndpoints.includes(endpoint)) {
 			return;
 		}
+		//if (endpoint === '/health' || req.url === '/') {
+		//  return;
+		//}
 
 		responseStatusCounter.add(1, {
 			endpoint,
@@ -22,5 +29,5 @@ export const handleResponseTime = responseTime(
 		endpointResponseTimeHistogram.record(responseTimeMs, {
 			endpoint,
 		});
-	}
-);
+	});
+};

--- a/src/index.ts
+++ b/src/index.ts
@@ -90,7 +90,7 @@ app.use(cors({ origin: '*' }));
 app.use(compression());
 app.set('trust proxy', 1);
 app.use(logHttp);
-app.use(handleResponseTime);
+app.use(handleResponseTime());
 
 // strip off /dlob, if the request comes from exchange history server LB
 app.use((req, _res, next) => {

--- a/src/serverLite.ts
+++ b/src/serverLite.ts
@@ -65,7 +65,7 @@ app.use(cors({ origin: '*' }));
 app.use(compression());
 app.set('trust proxy', 1);
 app.use(logHttp);
-app.use(handleResponseTime);
+app.use(handleResponseTime());
 
 // strip off /dlob, if the request comes from exchange history server LB
 app.use((req, _res, next) => {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,0 +1,9 @@
+export const MEASURED_ENDPOINTS = [
+	'/priorityFees',
+	'/batchPriorityFees',
+	'/topMakers',
+	'/l2',
+	'/batchL2',
+	'/batchL2Cache',
+	'/l3',
+];


### PR DESCRIPTION
This metric is the major source of metric label cardinality blow-up, restrict endpoint labels to only endpoints we care about.

<img width="1680" alt="image" src="https://github.com/user-attachments/assets/774e6951-7888-45d4-a874-c3bd068a342c">
