### PR TITLE
Pin non-prod deploy workflow actions

### DIFF
--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -10,12 +10,12 @@ jobs:
     runs-on: ubicloud
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744
         with:
           submodules: recursive
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_NON_PROD }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY_NON_PROD }}
@@ -23,10 +23,10 @@ jobs:
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: dlob-server
@@ -44,14 +44,14 @@ jobs:
     needs: [build]
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37
         with:
           aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_NON_PROD }}
           aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY_NON_PROD }}
           aws-region: ${{ secrets.EKS_NON_PROD_REGION }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8
         with:
           version: 'v1.30.0'
 


### PR DESCRIPTION
## Summary
- Pin all GitHub Actions in the non-prod deploy workflow to full-length commit SHAs.
- Replace the moving `aws-actions/configure-aws-credentials@master` ref with the latest stable release SHA.
- Pin deploy-step actions too so the workflow does not fail later under the same action policy.

## Test plan
- Verified the branch diff contains only `.github/workflows/master.yml`.
- No runtime build needed; workflow-only change.


Made with [Cursor](https://cursor.com)