### PR TITLE
chore(ci): migrate GitHub Actions to OIDC auth

### DIFF
--- a/.github/workflows/mainnet-beta.yml
+++ b/.github/workflows/mainnet-beta.yml
@@ -4,28 +4,32 @@ on:
   push:
     branches: [mainnet-beta]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubicloud
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: 'recursive'
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_PROD }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY_PROD }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_PROD }}
+          role-session-name: gha-${{ github.run_id }}
           aws-region: ${{ secrets.EKS_PROD_REGION }}
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: dlob-server
@@ -43,14 +47,14 @@ jobs:
     needs: [build]
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_PROD }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY_PROD }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_PROD }}
+          role-session-name: gha-${{ github.run_id }}
           aws-region: ${{ secrets.EKS_PROD_REGION }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3
         with:
           version: 'v1.30.0'
 

--- a/.github/workflows/master.yml
+++ b/.github/workflows/master.yml
@@ -5,28 +5,32 @@ on:
   push:
     branches: [master, staging]
 
+permissions:
+  id-token: write
+  contents: read
+
 jobs:
   build:
     runs-on: ubicloud
     steps:
       - name: Checkout Code
-        uses: actions/checkout@v3
+        uses: actions/checkout@f43a0e5ff2bd294095638e18286ca9a3d1956744 # v3
         with:
           submodules: recursive
 
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_NON_PROD }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY_NON_PROD }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_NONPROD }}
+          role-session-name: gha-${{ github.run_id }}
           aws-region: ${{ secrets.EKS_NON_PROD_REGION }}
 
       - name: Log in to Amazon ECR
         id: login-ecr
-        uses: aws-actions/amazon-ecr-login@v2
+        uses: aws-actions/amazon-ecr-login@fa648b43de3d4d023bcb3f89ed6940096949c419 # v2
 
       - name: Build and push
-        uses: docker/build-push-action@v6
+        uses: docker/build-push-action@10e90e3645eae34f1e60eeb005ba3a3d33f178e8 # v6
         env:
           ECR_REGISTRY: ${{ steps.login-ecr.outputs.registry }}
           ECR_REPOSITORY: dlob-server
@@ -44,14 +48,14 @@ jobs:
     needs: [build]
     steps:
       - name: Configure AWS credentials
-        uses: aws-actions/configure-aws-credentials@master
+        uses: aws-actions/configure-aws-credentials@ec61189d14ec14c8efccab744f656cffd0e33f37 # v6.1.0
         with:
-          aws-access-key-id: ${{ secrets.AWS_ACCESS_KEY_NON_PROD }}
-          aws-secret-access-key: ${{ secrets.AWS_SECRET_KEY_NON_PROD }}
+          role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_NONPROD }}
+          role-session-name: gha-${{ github.run_id }}
           aws-region: ${{ secrets.EKS_NON_PROD_REGION }}
 
       - name: Install kubectl
-        uses: azure/setup-kubectl@v3
+        uses: azure/setup-kubectl@901a10e89ea615cf61f57ac05cecdf23e7de06d8 # v3
         with:
           version: 'v1.30.0'
 


### PR DESCRIPTION
Replaces long-lived AWS_ACCESS_KEY_* secrets with short-lived STS credentials via GitHub OIDC.

## Changes
- Add workflow-level `permissions: { id-token: write, contents: read }`
- Replace `aws-access-key-id` / `aws-secret-access-key` with `role-to-assume: ${{ vars.AWS_DEPLOY_ROLE_PROD/NONPROD }}`
- Pin floating action refs to commit SHAs

## Prerequisites before merge
1. Set GitHub org-level variables `AWS_DEPLOY_ROLE_PROD` and `AWS_DEPLOY_ROLE_NONPROD` (role ARNs).
2. Update the IAM role trust policy in each account to include this repo's `sub` claims (will be applied centrally as part of the migration).

CI on this PR is expected to fail at the AWS credentials step until both of the above are in place.