### PR TITLE
deps: swap @drift-labs/sdk for @velocity-exchange/sdk 0.0.3

### DIFF
--- a/example/client.ts
+++ b/example/client.ts
@@ -17,7 +17,7 @@ import {
     PRICE_PRECISION,
     Wallet,
     WrappedEvent,
-} from "@drift-labs/sdk";
+} from "@velocity-exchange/sdk";
 import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 
 /********** SET THESE **********/

--- a/example/clientWithSlot.ts
+++ b/example/clientWithSlot.ts
@@ -24,7 +24,7 @@ import {
     PRICE_PRECISION,
     Wallet,
     WrappedEvent,
-} from "@drift-labs/sdk";
+} from "@velocity-exchange/sdk";
 import { Connection, Keypair, PublicKey } from "@solana/web3.js";
 
 /********** SET THESE **********/

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
-	"name": "@drift-labs/dlob-server",
+	"name": "@velocity-exchange/dlob-server",
 	"version": "0.1.0",
 	"author": "wphan",
 	"main": "lib/index.js",
@@ -9,8 +9,8 @@
 		"@aws-sdk/client-kinesis": "^3.830.0",
 		"@aws-sdk/util-retry": "^3.374.0",
 		"@coral-xyz/anchor": "^0.29.0",
-		"@drift-labs/common": "1.0.20",
-		"@drift-labs/sdk": "2.163.0-beta.13",
+		"@velocity-exchange/common": "0.0.1",
+		"@velocity-exchange/sdk": "0.0.3",
 		"@opentelemetry/api": "^1.1.0",
 		"@opentelemetry/auto-instrumentations-node": "^0.31.1",
 		"@opentelemetry/exporter-prometheus": "^0.31.0",
@@ -60,7 +60,9 @@
 		"ts-node": "^10.9.1"
 	},
 	"resolutions": {
-		"@solana/web3.js": "1.98.0"
+		"@solana/web3.js": "1.98.0",
+		"@drift-labs/sdk": "npm:@velocity-exchange/sdk@0.0.3",
+		"@velocity-exchange/sdk": "0.0.3"
 	},
 	"scripts": {
 		"prepare": "husky install",

--- a/src/athena/testRedisPolling.ts
+++ b/src/athena/testRedisPolling.ts
@@ -1,4 +1,7 @@
-import { RedisClient, RedisClientPrefix } from '@drift-labs/common/clients';
+import {
+	RedisClient,
+	RedisClientPrefix,
+} from '@velocity-exchange/common/clients';
 import { logger, setLogLevel } from '../utils/logger';
 
 setLogLevel('info');

--- a/src/core/metricsV2.ts
+++ b/src/core/metricsV2.ts
@@ -7,7 +7,7 @@ import {
 import { PrometheusExporter } from '@opentelemetry/exporter-prometheus';
 import { logger } from '../utils/logger';
 import { PublicKey } from '@solana/web3.js';
-import { UserAccount } from '@drift-labs/sdk';
+import { UserAccount } from '@velocity-exchange/sdk';
 import {
 	BatchObservableResult,
 	Attributes,

--- a/src/core/middleware.ts
+++ b/src/core/middleware.ts
@@ -1,7 +1,7 @@
 import { Request, Response } from 'express';
 import responseTime = require('response-time');
 import { MEASURED_ENDPOINTS } from '../utils/constants';
-import { SlotSource } from '@drift-labs/sdk';
+import { SlotSource } from '@velocity-exchange/sdk';
 import {
 	evaluateHealth,
 	globalHealthState,

--- a/src/dlob-subscriber/DLOBSubscriberIO.ts
+++ b/src/dlob-subscriber/DLOBSubscriberIO.ts
@@ -17,8 +17,8 @@ import {
 	getLimitPrice,
 	isOperationPaused,
 	isVariant,
-} from '@drift-labs/sdk';
-import { RedisClient } from '@drift-labs/common/clients';
+} from '@velocity-exchange/sdk';
+import { RedisClient } from '@velocity-exchange/common/clients';
 import { logger } from '../utils/logger';
 import {
 	SubscriberLookup,
@@ -31,7 +31,7 @@ import {
 import { OffloadQueue } from '../utils/offload';
 import { setHealthStatus, HEALTH_STATUS } from '../core/healthCheck';
 import { CounterValue } from '../core/metricsV2';
-import { COMMON_MATH } from '@drift-labs/common';
+import { COMMON_MATH } from '@velocity-exchange/common';
 
 export type wsMarketArgs = {
 	marketIndex: number;
@@ -133,10 +133,7 @@ export class DLOBSubscriberIO extends DLOBSubscriber {
 				depth: -1,
 				includeVamm: false,
 				updateOnChange: false,
-				fallbackL2Generators: [
-					config.spotMarketSubscribers[market.marketIndex].phoenix,
-					config.spotMarketSubscribers[market.marketIndex].openbook,
-				].filter((a) => !!a),
+				fallbackL2Generators: [],
 				tickSize:
 					config.spotMarketSubscribers[market.marketIndex].tickSize ?? ONE,
 			});
@@ -187,7 +184,6 @@ export class DLOBSubscriberIO extends DLOBSubscriber {
 								marketArgs.marketIndex
 							),
 							true,
-							undefined,
 							new BN(this.slotSource.getSlot())
 						);
 

--- a/src/dlob-subscriber/OrderSubscriberFiltered.ts
+++ b/src/dlob-subscriber/OrderSubscriberFiltered.ts
@@ -2,7 +2,7 @@ import {
 	OrderSubscriber,
 	OrderSubscriberConfig,
 	UserAccount,
-} from '@drift-labs/sdk';
+} from '@velocity-exchange/sdk';
 
 export class OrderSubscriberFiltered extends OrderSubscriber {
 	public ignoreList: string[];

--- a/src/dlobProvider.ts
+++ b/src/dlobProvider.ts
@@ -1,18 +1,14 @@
 import {
 	DLOB,
 	OrderSubscriber,
-	ProtectMakerParamsMap,
 	UserAccount,
 	UserMap,
-} from '@drift-labs/sdk';
+} from '@velocity-exchange/sdk';
 import { PublicKey } from '@solana/web3.js';
 
 export type DLOBProvider = {
 	subscribe(): Promise<void>;
-	getDLOB(
-		slot: number,
-		protectedMakerParamsMap?: ProtectMakerParamsMap
-	): Promise<DLOB>;
+	getDLOB(slot: number): Promise<DLOB>;
 	getUniqueAuthorities(): PublicKey[];
 	getUserAccounts(): Generator<{
 		userAccount: UserAccount;
@@ -29,11 +25,8 @@ export function getDLOBProviderFromUserMap(userMap: UserMap): DLOBProvider {
 		subscribe: async () => {
 			await userMap.subscribe();
 		},
-		getDLOB: async (
-			slot: number,
-			protectedMakerParamsMap?: ProtectMakerParamsMap
-		) => {
-			return await userMap.getDLOB(slot, protectedMakerParamsMap);
+		getDLOB: async (slot: number) => {
+			return await userMap.getDLOB(slot);
 		},
 		getUniqueAuthorities: () => {
 			return userMap.getUniqueAuthorities();
@@ -68,11 +61,8 @@ export function getDLOBProviderFromOrderSubscriber(
 		subscribe: async () => {
 			await orderSubscriber.subscribe();
 		},
-		getDLOB: async (
-			slot: number,
-			protectedMakerParamsMap?: ProtectMakerParamsMap
-		) => {
-			return await orderSubscriber.getDLOB(slot, protectedMakerParamsMap);
+		getDLOB: async (slot: number) => {
+			return await orderSubscriber.getDLOB(slot);
 		},
 		getUniqueAuthorities: () => {
 			const authorities = new Set<string>();

--- a/src/index.ts
+++ b/src/index.ts
@@ -23,8 +23,11 @@ import {
 	MarketTypeStr,
 	AssetType,
 	MarketType,
-} from '@drift-labs/sdk';
-import { RedisClient, RedisClientPrefix } from '@drift-labs/common/clients';
+} from '@velocity-exchange/sdk';
+import {
+	RedisClient,
+	RedisClientPrefix,
+} from '@velocity-exchange/common/clients';
 
 import { logger, setLogLevel } from './utils/logger';
 
@@ -50,7 +53,7 @@ import FEATURE_FLAGS from './utils/featureFlags';
 import { getDLOBProviderFromOrderSubscriber } from './dlobProvider';
 import { setGlobalDispatcher, Agent } from 'undici';
 import { HermesClient } from '@pythnetwork/hermes-client';
-import { COMMON_UI_UTILS, ENUM_UTILS } from '@drift-labs/common';
+import { COMMON_UI_UTILS, ENUM_UTILS } from '@velocity-exchange/common';
 import { AuctionParamArgs } from './utils/types';
 import { TakerFillVsOracleBpsRedisResult } from './athena/repositories/fillQualityAnalytics';
 

--- a/src/publishers/dlobPublisher.ts
+++ b/src/publishers/dlobPublisher.ts
@@ -10,26 +10,21 @@ import {
 	SlotSource,
 	DriftClientSubscriptionConfig,
 	SlotSubscriber,
-	isVariant,
 	OracleInfo,
 	PerpMarketConfig,
 	SpotMarketConfig,
-	PhoenixSubscriber,
 	decodeName,
 	ONE,
-	WebSocketAccountSubscriberV2,
 	OrderSubscriberConfig,
 	GrpcConfigs,
-} from '@drift-labs/sdk';
-import { RedisClient, RedisClientPrefix } from '@drift-labs/common/clients';
+} from '@velocity-exchange/sdk';
+import {
+	RedisClient,
+	RedisClientPrefix,
+} from '@velocity-exchange/common/clients';
 
 import { logger, setLogLevel } from '../utils/logger';
-import {
-	SubscriberLookup,
-	getOpenbookSubscriber,
-	parsePositiveIntArray,
-	sleep,
-} from '../utils/utils';
+import { SubscriberLookup, parsePositiveIntArray, sleep } from '../utils/utils';
 import {
 	DLOBSubscriberIO,
 	wsMarketInfo,
@@ -49,7 +44,7 @@ import {
 	FillQualityAnalyticsRepository,
 	TakerFillVsOracleBpsRedisResult,
 } from '../athena/repositories/fillQualityAnalytics';
-import { CommitmentLevel } from '@drift-labs/sdk/lib/node/isomorphic/grpc';
+import { CommitmentLevel } from '@velocity-exchange/sdk/lib/node/isomorphic/grpc';
 
 setGlobalDispatcher(
 	new Agent({
@@ -304,76 +299,8 @@ const initializeAllMarketSubscribers = async (driftClient: DriftClient) => {
 
 	for (const market of driftClient.getSpotMarketAccounts()) {
 		markets[market.marketIndex] = {
-			phoenix: undefined,
+			tickSize: market?.orderTickSize ?? ONE,
 		};
-		const marketConfig = sdkConfig.SPOT_MARKETS[market.marketIndex];
-
-		if (marketConfig.phoenixMarket) {
-			const phoenixConfigAccount =
-				await driftClient.getPhoenixV1FulfillmentConfig(
-					marketConfig.phoenixMarket
-				);
-			if (isVariant(phoenixConfigAccount.status, 'enabled')) {
-				logger.info(
-					`Loading phoenix subscriber for spot market ${market.marketIndex}`
-				);
-				const bulkAccountLoader = new BulkAccountLoader(
-					driftClient.connection,
-					stateCommitment,
-					2_000
-				);
-				const phoenixSubscriber = new PhoenixSubscriber({
-					connection: driftClient.connection,
-					programId: new PublicKey(sdkConfig.PHOENIX),
-					marketAddress: phoenixConfigAccount.phoenixMarket,
-					accountSubscription: {
-						type: 'polling',
-						accountLoader: bulkAccountLoader,
-					},
-				});
-				await phoenixSubscriber.subscribe();
-				// Test get L2 to know if we should add
-				try {
-					phoenixSubscriber.getL2Asks();
-					phoenixSubscriber.getL2Bids();
-					markets[market.marketIndex].phoenix = phoenixSubscriber;
-				} catch (e) {
-					logger.info(
-						`Excluding phoenix for ${market.marketIndex}, error: ${e}`
-					);
-				}
-			}
-		}
-
-		if (marketConfig.openbookMarket) {
-			const openbookMarketAccount =
-				await driftClient.getOpenbookV2FulfillmentConfig(
-					marketConfig.openbookMarket
-				);
-
-			if (isVariant(openbookMarketAccount.status, 'enabled')) {
-				logger.info(
-					`Loading openbook subscriber for spot market ${market.marketIndex}`
-				);
-				const openbookSubscriber = getOpenbookSubscriber(
-					driftClient,
-					marketConfig,
-					sdkConfig
-				);
-				await openbookSubscriber.subscribe();
-				try {
-					openbookSubscriber.getL2Asks();
-					openbookSubscriber.getL2Bids();
-					markets[market.marketIndex].openbook = openbookSubscriber;
-				} catch (e) {
-					logger.info(
-						`Excluding openbook for ${market.marketIndex}, error: ${e}`
-					);
-				}
-			}
-		}
-
-		markets[market.marketIndex].tickSize = market?.orderTickSize ?? ONE;
 	}
 
 	return markets;
@@ -453,7 +380,6 @@ const main = async () => {
 			commitment: stateCommitment,
 			resubTimeoutMs: 30_000,
 			logResubMessages: true,
-			perpMarketAccountSubscriber: WebSocketAccountSubscriberV2,
 		};
 		slotSubscriber = new SlotSubscriber(connection, {
 			resubTimeoutMs: 10_000,
@@ -586,7 +512,6 @@ const main = async () => {
 		perpMarketInfos,
 		spotMarketInfos,
 		killSwitchSlotDiffThreshold: KILLSWITCH_SLOT_DIFF_THRESHOLD,
-		protectedMakerView: false,
 	});
 	await dlobSubscriber.subscribe();
 
@@ -601,7 +526,6 @@ const main = async () => {
 		perpMarketInfos,
 		spotMarketInfos,
 		killSwitchSlotDiffThreshold: KILLSWITCH_SLOT_DIFF_THRESHOLD,
-		protectedMakerView: false,
 		indicativeQuotesRedisClient: indicativeRedisClient,
 		enableOffloadQueue,
 		offloadQueueCounter: kinesisRecordsSentCounter,

--- a/src/publishers/priorityFeesPublisher.ts
+++ b/src/publishers/priorityFeesPublisher.ts
@@ -9,8 +9,11 @@ import {
 	Wallet,
 	BulkAccountLoader,
 	getMarketsAndOraclesForSubscription,
-} from '@drift-labs/sdk';
-import { RedisClient, RedisClientPrefix } from '@drift-labs/common/clients';
+} from '@velocity-exchange/sdk';
+import {
+	RedisClient,
+	RedisClientPrefix,
+} from '@velocity-exchange/common/clients';
 
 import { logger, setLogLevel } from '../utils/logger';
 import { sleep } from '../utils/utils';
@@ -202,18 +205,6 @@ const main = async () => {
 
 		const driftMarket = driftClient.getSpotMarketAccount(market.marketIndex);
 		pubkeysForMarket.push(driftMarket.pubkey.toString());
-
-		if (market.serumMarket) {
-			pubkeysForMarket.push(market.serumMarket.toString());
-		}
-
-		if (market.phoenixMarket) {
-			pubkeysForMarket.push(market.phoenixMarket.toString());
-		}
-
-		if (market.openbookMarket) {
-			pubkeysForMarket.push(market.openbookMarket.toString());
-		}
 
 		spotMarketPubkeys.push({
 			marketIndex: market.marketIndex,

--- a/src/publishers/tests/tradeMetrics.test.ts
+++ b/src/publishers/tests/tradeMetrics.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from '@jest/globals';
-import { BASE_PRECISION, PRICE_PRECISION } from '@drift-labs/sdk';
+import { BASE_PRECISION, PRICE_PRECISION } from '@velocity-exchange/sdk';
 import {
 	getAbsoluteBpsDiff,
 	getCompetitiveLiquidity,

--- a/src/publishers/tradeMetrics.ts
+++ b/src/publishers/tradeMetrics.ts
@@ -1,4 +1,4 @@
-import { BASE_PRECISION, PRICE_PRECISION } from '@drift-labs/sdk';
+import { BASE_PRECISION, PRICE_PRECISION } from '@velocity-exchange/sdk';
 
 export type FillEventStub = {
 	ts: number;

--- a/src/publishers/tradesPublisher.ts
+++ b/src/publishers/tradesPublisher.ts
@@ -19,8 +19,11 @@ import {
 	BN,
 	OrderActionRecord,
 	Event,
-} from '@drift-labs/sdk';
-import { RedisClient, RedisClientPrefix } from '@drift-labs/common/clients';
+} from '@velocity-exchange/sdk';
+import {
+	RedisClient,
+	RedisClientPrefix,
+} from '@velocity-exchange/common/clients';
 import express from 'express';
 
 import { Metrics } from '../core/metricsV2';
@@ -255,16 +258,20 @@ const main = async () => {
 
 	await slotSubscriber.subscribe();
 
-	const eventSubscriber = new EventSubscriber(connection, driftClient.program, {
-		maxTx: 8192,
-		maxEventsPerType: 4096,
-		orderBy: 'client',
-		commitment: 'confirmed',
-		logProviderConfig: {
-			type: 'polling',
-			frequency: 1000,
-		},
-	});
+	const eventSubscriber = new EventSubscriber(
+		connection,
+		driftClient.program as any,
+		{
+			maxTx: 8192,
+			maxEventsPerType: 4096,
+			orderBy: 'client',
+			commitment: 'confirmed',
+			logProviderConfig: {
+				type: 'polling',
+				frequency: 1000,
+			},
+		}
+	);
 
 	await eventSubscriber.subscribe();
 

--- a/src/scripts/publishUnsettledPnlUsers.ts
+++ b/src/scripts/publishUnsettledPnlUsers.ts
@@ -1,5 +1,8 @@
-import { RedisClient, RedisClientPrefix } from '@drift-labs/common/clients';
-import { sleep } from '@drift-labs/common';
+import {
+	RedisClient,
+	RedisClientPrefix,
+} from '@velocity-exchange/common/clients';
+import { sleep } from '@velocity-exchange/common';
 import {
 	BigNum,
 	DriftClient,
@@ -13,7 +16,7 @@ import {
 	ZERO,
 	calculateClaimablePnl,
 	decodeUser,
-} from '@drift-labs/sdk';
+} from '@velocity-exchange/sdk';
 import { Connection, Keypair } from '@solana/web3.js';
 import { logger } from '../utils/logger';
 import Bottleneck from 'bottleneck';
@@ -213,8 +216,7 @@ const buildUserMarketLists = (
 					if (
 						!perpPosition ||
 						(perpPosition.baseAssetAmount.eq(ZERO) &&
-							perpPosition.quoteAssetAmount.eq(ZERO) &&
-							perpPosition.lpShares.eq(ZERO))
+							perpPosition.quoteAssetAmount.eq(ZERO))
 					)
 						return [];
 

--- a/src/scripts/submitMockJitMetricsData.ts
+++ b/src/scripts/submitMockJitMetricsData.ts
@@ -1,4 +1,4 @@
-import { RedisClient } from '@drift-labs/common/clients';
+import { RedisClient } from '@velocity-exchange/common/clients';
 
 require('dotenv').config();
 

--- a/src/serverLite.ts
+++ b/src/serverLite.ts
@@ -12,8 +12,11 @@ import {
 	initialize,
 	MarketType,
 	getVariant,
-} from '@drift-labs/sdk';
-import { RedisClient, RedisClientPrefix } from '@drift-labs/common/clients';
+} from '@velocity-exchange/sdk';
+import {
+	RedisClient,
+	RedisClientPrefix,
+} from '@velocity-exchange/common/clients';
 
 import { logger, setLogLevel } from './utils/logger';
 

--- a/src/utils/tests/auctionParams.test.ts
+++ b/src/utils/tests/auctionParams.test.ts
@@ -7,7 +7,7 @@ import {
 	QUOTE_PRECISION,
 	PRICE_PRECISION,
 	BASE_PRECISION,
-} from '@drift-labs/sdk';
+} from '@velocity-exchange/sdk';
 import {
 	createMarketBasedAuctionParams,
 	mapToMarketOrderParams,

--- a/src/utils/types.ts
+++ b/src/utils/types.ts
@@ -1,5 +1,5 @@
-import { AssetType, MarketTypeStr } from '@drift-labs/sdk';
-import { TradeOffsetPrice } from '@drift-labs/common';
+import { AssetType, MarketTypeStr } from '@velocity-exchange/sdk';
+import { TradeOffsetPrice } from '@velocity-exchange/common';
 
 export type AuctionParamArgs = {
 	// mandatory args

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -6,12 +6,8 @@ import {
 	L2OrderBook,
 	L3OrderBook,
 	MarketType,
-	OpenbookV2Subscriber,
 	OraclePriceData,
-	PhoenixSubscriber,
 	PublicKey,
-	SerumSubscriber,
-	SpotMarketConfig,
 	decodeUser,
 	isVariant,
 	PositionDirection,
@@ -23,9 +19,9 @@ import {
 	MainnetSpotMarkets,
 	DevnetSpotMarkets,
 	PERCENTAGE_PRECISION_EXP,
-} from '@drift-labs/sdk';
-import { RedisClient } from '@drift-labs/common/clients';
-import { TradeOffsetPrice } from '@drift-labs/common';
+} from '@velocity-exchange/sdk';
+import { RedisClient } from '@velocity-exchange/common/clients';
+import { TradeOffsetPrice } from '@velocity-exchange/common';
 import { logger } from './logger';
 import { NextFunction, Request, Response } from 'express';
 import FEATURE_FLAGS from './featureFlags';
@@ -33,7 +29,7 @@ import { Connection } from '@solana/web3.js';
 import { wsMarketArgs } from 'src/dlob-subscriber/DLOBSubscriberIO';
 import { DEFAULT_AUCTION_PARAMS, MID_MAJOR_MARKETS } from './constants';
 import { AuctionParamArgs } from './types';
-import { COMMON_MATH, ENUM_UTILS } from '@drift-labs/common';
+import { COMMON_MATH, ENUM_UTILS } from '@velocity-exchange/common';
 import { TakerFillVsOracleBpsRedisResult } from '../athena/repositories/fillQualityAnalytics';
 
 const MAX_FILL_QUALITY_AGE_MS = 10 * 60 * 1000; // 10 minutes
@@ -614,60 +610,8 @@ export function errorHandler(
 	}
 }
 
-/**
- * Spot market utils
- */
-
-export const getPhoenixSubscriber = (
-	driftClient: DriftClient,
-	marketConfig: SpotMarketConfig,
-	sdkConfig
-): PhoenixSubscriber => {
-	return new PhoenixSubscriber({
-		connection: driftClient.connection,
-		programId: new PublicKey(sdkConfig.PHOENIX),
-		marketAddress: marketConfig.phoenixMarket,
-		accountSubscription: {
-			type: 'websocket',
-		},
-	});
-};
-
-export const getSerumSubscriber = (
-	driftClient: DriftClient,
-	marketConfig: SpotMarketConfig,
-	sdkConfig
-): SerumSubscriber => {
-	return new SerumSubscriber({
-		connection: driftClient.connection,
-		programId: new PublicKey(sdkConfig.SERUM_V3),
-		marketAddress: marketConfig.serumMarket,
-		accountSubscription: {
-			type: 'websocket',
-		},
-	});
-};
-
-export const getOpenbookSubscriber = (
-	driftClient: DriftClient,
-	marketConfig: SpotMarketConfig,
-	sdkConfig
-): OpenbookV2Subscriber => {
-	return new OpenbookV2Subscriber({
-		connection: driftClient.connection,
-		programId: new PublicKey(sdkConfig.OPENBOOK),
-		marketAddress: marketConfig.openbookMarket,
-		accountSubscription: {
-			type: 'websocket',
-		},
-	});
-};
-
 export type SubscriberLookup = {
 	[marketIndex: number]: {
-		phoenix?: PhoenixSubscriber;
-		serum?: SerumSubscriber;
-		openbook?: OpenbookV2Subscriber;
 		tickSize?: BN;
 	};
 };

--- a/src/wsConnectionManager.ts
+++ b/src/wsConnectionManager.ts
@@ -4,8 +4,11 @@ import * as http from 'http';
 import compression from 'compression';
 import { WebSocket, WebSocketServer } from 'ws';
 import { sleep, selectMostRecentBySlot, GROUPING_OPTIONS } from './utils/utils';
-import { DriftEnv, PerpMarkets, SpotMarkets } from '@drift-labs/sdk';
-import { RedisClient, RedisClientPrefix } from '@drift-labs/common/clients';
+import { DriftEnv, PerpMarkets, SpotMarkets } from '@velocity-exchange/sdk';
+import {
+	RedisClient,
+	RedisClientPrefix,
+} from '@velocity-exchange/common/clients';
 import { Metrics, GaugeValue } from './core/metricsV2';
 
 // Stream selector with hysteresis to prevent flip-flopping between sources

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -15,7 +15,7 @@
 		"rootDir": "src",
 		"outDir": "./lib",
 		"paths": {
-			"@drift-labs/common/clients": ["./node_modules/@drift-labs/common/lib/clients"]
+			"@velocity-exchange/common/clients": ["./node_modules/@velocity-exchange/common/lib/clients"]
 		}
 	},
 	"include": ["src/**/*"],

--- a/yarn.lock
+++ b/yarn.lock
@@ -1095,11 +1095,6 @@
   resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.27.6.tgz#ec4070a04d76bae8ddbb10770ba55714a417b7c6"
   integrity sha512-vbavdySgbTTrmFE+EsiqUTzlOr5bzlnJtUv9PynGCAKvfQqjIXbvFdumPM/GxMDfyuGMJaJAU6TO4zc1Jf1i8Q==
 
-"@babel/runtime@^7.17.2":
-  version "7.28.6"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.28.6.tgz#d267a43cb1836dc4d182cce93ae75ba954ef6d2b"
-  integrity sha512-05WQkdpL9COIMz4LjTxGpPNCdlpyimKppYNoJ5Di5EUObifl8t4tuLuUBBZEpoLYOmfvIWrsp9fCl0HoPRVTdA==
-
 "@babel/template@^7.27.2", "@babel/template@^7.3.3":
   version "7.27.2"
   resolved "https://registry.yarnpkg.com/@babel/template/-/template-7.27.2.tgz#fa78ceed3c4e7b63ebf6cb39e5852fca45f6809d"
@@ -1165,33 +1160,7 @@
     superstruct "^0.15.4"
     toml "^3.0.0"
 
-"@coral-xyz/anchor-30@npm:@coral-xyz/anchor@0.30.1":
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor/-/anchor-0.30.1.tgz#17f3e9134c28cd0ea83574c6bab4e410bcecec5d"
-  integrity sha512-gDXFoF5oHgpriXAaLpxyWBHdCs8Awgf/gLHIo6crv7Aqm937CNdY+x+6hoj7QR5vaJV7MxWSQ0NGFzL3kPbWEQ==
-  dependencies:
-    "@coral-xyz/anchor-errors" "^0.30.1"
-    "@coral-xyz/borsh" "^0.30.1"
-    "@noble/hashes" "^1.3.1"
-    "@solana/web3.js" "^1.68.0"
-    bn.js "^5.1.2"
-    bs58 "^4.0.1"
-    buffer-layout "^1.2.2"
-    camelcase "^6.3.0"
-    cross-fetch "^3.1.5"
-    crypto-hash "^1.3.0"
-    eventemitter3 "^4.0.7"
-    pako "^2.0.3"
-    snake-case "^3.0.4"
-    superstruct "^0.15.4"
-    toml "^3.0.0"
-
-"@coral-xyz/anchor-errors@^0.30.1":
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/@coral-xyz/anchor-errors/-/anchor-errors-0.30.1.tgz#bdfd3a353131345244546876eb4afc0e125bec30"
-  integrity sha512-9Mkradf5yS5xiLWrl9WrpjqOrAV+/W2RQHDlbnAZBivoGpOs1ECjoDCkVk4aRG8ZdiFiB8zQEVlxf+8fKkmSfQ==
-
-"@coral-xyz/anchor@0.29.0", "@coral-xyz/anchor@^0.29.0":
+"@coral-xyz/anchor@^0.29.0":
   version "0.29.0"
   resolved "https://registry.yarnpkg.com/@coral-xyz/anchor/-/anchor-0.29.0.tgz#bd0be95bedfb30a381c3e676e5926124c310ff12"
   integrity sha512-eny6QNG0WOwqV0zQ7cs/b1tIuzZGmP7U7EcH+ogt4Gdbl8HDmIYVMh/9aTmYZPaFWjtUaI8qSn73uYEXWfATdA==
@@ -1238,14 +1207,6 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
-"@coral-xyz/borsh@^0.30.1":
-  version "0.30.1"
-  resolved "https://registry.yarnpkg.com/@coral-xyz/borsh/-/borsh-0.30.1.tgz#869d8833abe65685c72e9199b8688477a4f6b0e3"
-  integrity sha512-aaxswpPrCFKl8vZTbxLssA2RvwX2zmKLlRCIktJOwW+VpVwYtXRtlWiIP+c2pPRKneiTiWCN2GEMSH9j1zTlWQ==
-  dependencies:
-    bn.js "^5.1.2"
-    buffer-layout "^1.2.0"
-
 "@cspotcode/source-map-support@^0.8.0":
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/@cspotcode/source-map-support/-/source-map-support-0.8.1.tgz#00629c35a688e05a88b1cda684fb9d5e73f000a1"
@@ -1262,40 +1223,15 @@
     enabled "2.0.x"
     kuler "^2.0.0"
 
-"@drift-labs/common@1.0.20":
-  version "1.0.20"
-  resolved "https://registry.yarnpkg.com/@drift-labs/common/-/common-1.0.20.tgz#9135da5d2dc11adfe7074afda45208e421d61a19"
-  integrity sha512-C1QYUstbOreNI+DHX84hjbwuZvPHDR3fE7P07GlBqsUSZt1bbsfzeZByH6Jhm1Zr7JSbg/jX9LBQ4c8ShxSBEA==
-  dependencies:
-    "@drift-labs/sdk" "^2.155.0-beta.5"
-    "@slack/web-api" "6.4.0"
-    "@solana/spl-token" "0.3.8"
-    "@solana/web3.js" "1.98.0"
-    bcryptjs-react "2.4.6"
-    cerializr "3.1.4"
-    dotenv "^17.2.2"
-    immer "10.0.3"
-    ioredis "5.4.1"
-    isomorphic-ws "^5.0.0"
-    localstorage-memory "1.0.3"
-    rxjs "7.8.2"
-    tiny-invariant "1.3.1"
-    tweetnacl "1.0.3"
-    winston "3.13.0"
-    winston-slack-webhook-transport "2.3.5"
-
-"@drift-labs/sdk@2.163.0-beta.13":
-  version "2.163.0-beta.13"
-  resolved "https://registry.yarnpkg.com/@drift-labs/sdk/-/sdk-2.163.0-beta.13.tgz#00453116e2bae014597998331020f79af91957c7"
-  integrity sha512-6I1O1GrRD8HBqSkjR4ByvlIckcUtjLwcRhtuWukW8oJitrtyr/K2WRfaiom6/39VkNLBDGQkSLKliX/zuWIN+A==
+"@drift-labs/sdk@npm:@velocity-exchange/sdk@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@velocity-exchange/sdk/-/sdk-0.0.3.tgz#e15f910e6564aea8b37f32e0f43127267ed93edd"
+  integrity sha512-n1CYqk7UCJeMm+nC8DCSiHozVYOunWY8JqXtxfFOA8WTivi81w0iFMTxPS29hswWrBqejpiOEG79tJ8tHaMafQ==
   dependencies:
     "@anchor-lang/core" "1.0.1"
     "@coral-xyz/anchor" "npm:@anchor-lang/core@1.0.1"
     "@coral-xyz/anchor-29" "npm:@coral-xyz/anchor@0.29.0"
-    "@ellipsis-labs/phoenix-sdk" "1.4.5"
-    "@msgpack/msgpack" "^3.1.2"
-    "@openbook-dex/openbook-v2" "0.2.10"
-    "@project-serum/serum" "0.13.65"
+    "@msgpack/msgpack" "3.1.2"
     "@pythnetwork/client" "2.5.3"
     "@pythnetwork/price-service-sdk" "1.7.1"
     "@pythnetwork/pyth-lazer-sdk" "6.0.0"
@@ -1303,7 +1239,7 @@
     "@solana/web3.js" "1.98.0"
     "@triton-one/yellowstone-grpc" "5.0.5"
     anchor-bankrun "0.5.0"
-    gill "^0.10.2"
+    gill "0.10.2"
     nanoid "3.3.4"
     node-cache "5.1.2"
     solana-bankrun "0.4.0"
@@ -1316,54 +1252,6 @@
     zstddec "0.1.0"
   optionalDependencies:
     helius-laserstream "0.1.8"
-
-"@drift-labs/sdk@^2.155.0-beta.5":
-  version "2.155.0-beta.6"
-  resolved "https://registry.yarnpkg.com/@drift-labs/sdk/-/sdk-2.155.0-beta.6.tgz#979a2cfeebbed92dbd2cb97f82a3cbda9623571d"
-  integrity sha512-ttxjjIKbDumoSEQo5M4Cb4WJPcHuR8kYHoyOka3uAD5aHl0YXGyX1ckIARsUcL0mnpgExGN3tETY90whv5y+eQ==
-  dependencies:
-    "@coral-xyz/anchor" "0.29.0"
-    "@coral-xyz/anchor-30" "npm:@coral-xyz/anchor@0.30.1"
-    "@ellipsis-labs/phoenix-sdk" "1.4.5"
-    "@grpc/grpc-js" "1.14.0"
-    "@msgpack/msgpack" "^3.1.2"
-    "@openbook-dex/openbook-v2" "0.2.10"
-    "@project-serum/serum" "0.13.65"
-    "@pythnetwork/client" "2.5.3"
-    "@pythnetwork/price-service-sdk" "1.7.1"
-    "@solana/spl-token" "0.4.13"
-    "@solana/web3.js" "1.98.0"
-    "@switchboard-xyz/common" "3.0.14"
-    "@switchboard-xyz/on-demand" "2.4.1"
-    "@triton-one/yellowstone-grpc" "1.4.1"
-    anchor-bankrun "0.3.0"
-    gill "^0.10.2"
-    helius-laserstream "0.1.8"
-    nanoid "3.3.4"
-    node-cache "5.1.2"
-    rpc-websockets "7.5.1"
-    solana-bankrun "0.3.1"
-    strict-event-emitter-types "2.0.0"
-    tweetnacl "1.0.3"
-    tweetnacl-util "0.15.1"
-    uuid "8.3.2"
-    yargs "17.7.2"
-    zod "4.0.17"
-    zstddec "0.1.0"
-
-"@ellipsis-labs/phoenix-sdk@1.4.5":
-  version "1.4.5"
-  resolved "https://registry.yarnpkg.com/@ellipsis-labs/phoenix-sdk/-/phoenix-sdk-1.4.5.tgz#42cf8de8463b32c910ab8844eae71ca082a6773a"
-  integrity sha512-vEYgMXuV5/mpnpEi+VK4HO8f6SheHtVLdHHlULBiDN1eECYmL67gq+/cRV7Ar6jAQ7rJZL7xBxhbUW5kugMl6A==
-  dependencies:
-    "@metaplex-foundation/beet" "^0.7.1"
-    "@metaplex-foundation/rustbin" "^0.3.1"
-    "@metaplex-foundation/solita" "^0.12.2"
-    "@solana/spl-token" "^0.3.7"
-    "@types/node" "^18.11.13"
-    bn.js "^5.2.1"
-    borsh "^0.7.0"
-    bs58 "^5.0.0"
 
 "@esbuild/aix-ppc64@0.24.2":
   version "0.24.2"
@@ -1533,42 +1421,6 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@fastify/error/-/error-2.0.0.tgz#a9f94af56eb934f0ab1ce4ef9f0ced6ebf2319dc"
   integrity sha512-wI3fpfDT0t7p8E6dA2eTECzzOd+bZsZCJ2Hcv+Onn2b7ZwK3RwD27uW2QDaMtQhAfWQQP+WNK7nKf0twLsBf9w==
-
-"@grpc/grpc-js@1.14.0":
-  version "1.14.0"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.14.0.tgz#a3c47e7816ca2b4d5490cba9e06a3cf324e675ad"
-  integrity sha512-N8Jx6PaYzcTRNzirReJCtADVoq4z7+1KQ4E70jTg/koQiMoUSN1kbNjPOqpPbhMFhfU1/l7ixspPl8dNY+FoUg==
-  dependencies:
-    "@grpc/proto-loader" "^0.8.0"
-    "@js-sdsl/ordered-map" "^4.4.2"
-
-"@grpc/grpc-js@^1.8.0":
-  version "1.13.4"
-  resolved "https://registry.yarnpkg.com/@grpc/grpc-js/-/grpc-js-1.13.4.tgz#922fbc496e229c5fa66802d2369bf181c1df1c5a"
-  integrity sha512-GsFaMXCkMqkKIvwCQjCrwH+GHbPKBjhwo/8ZuUkWHqbI73Kky9I+pQltrlT0+MWpedCoosda53lgjYfyEPgxBg==
-  dependencies:
-    "@grpc/proto-loader" "^0.7.13"
-    "@js-sdsl/ordered-map" "^4.4.2"
-
-"@grpc/proto-loader@^0.7.13":
-  version "0.7.15"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.7.15.tgz#4cdfbf35a35461fc843abe8b9e2c0770b5095e60"
-  integrity sha512-tMXdRCfYVixjuFK+Hk0Q1s38gV9zDiDJfWL3h1rv4Qc39oILCu1TRTDt7+fGUI8K4G1Fj125Hx/ru3azECWTyQ==
-  dependencies:
-    lodash.camelcase "^4.3.0"
-    long "^5.0.0"
-    protobufjs "^7.2.5"
-    yargs "^17.7.2"
-
-"@grpc/proto-loader@^0.8.0":
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/@grpc/proto-loader/-/proto-loader-0.8.0.tgz#b6c324dd909c458a0e4aa9bfd3d69cf78a4b9bd8"
-  integrity sha512-rc1hOQtjIWGxcxpb9aHAfLpIctjEnsDehj0DAiVfBlmT84uvR0uUtN2hEi/ecvWVjXUGf5qPF4qEgiLOx1YIMQ==
-  dependencies:
-    lodash.camelcase "^4.3.0"
-    long "^5.0.0"
-    protobufjs "^7.5.3"
-    yargs "^17.7.2"
 
 "@hapi/b64@5.x.x":
   version "5.0.0"
@@ -1971,70 +1823,10 @@
     "@jridgewell/resolve-uri" "^3.1.0"
     "@jridgewell/sourcemap-codec" "^1.4.14"
 
-"@js-sdsl/ordered-map@^4.4.2":
-  version "4.4.2"
-  resolved "https://registry.yarnpkg.com/@js-sdsl/ordered-map/-/ordered-map-4.4.2.tgz#9299f82874bab9e4c7f9c48d865becbfe8d6907c"
-  integrity sha512-iUKgm52T8HOE/makSxjqoWhe95ZJA1/G1sYsGev2JDKUSS14KAgg1LHb+Ba+IPow0xflbnSkOsZcO08C7w1gYw==
-
-"@metaplex-foundation/beet-solana@^0.3.0":
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/@metaplex-foundation/beet-solana/-/beet-solana-0.3.1.tgz#4b37cda5c7f32ffd2bdd8b3164edc05c6463ab35"
-  integrity sha512-tgyEl6dvtLln8XX81JyBvWjIiEcjTkUwZbrM5dIobTmoqMuGewSyk9CClno8qsMsFdB5T3jC91Rjeqmu/6xk2g==
-  dependencies:
-    "@metaplex-foundation/beet" ">=0.1.0"
-    "@solana/web3.js" "^1.56.2"
-    bs58 "^5.0.0"
-    debug "^4.3.4"
-
-"@metaplex-foundation/beet@>=0.1.0", "@metaplex-foundation/beet@^0.7.1":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@metaplex-foundation/beet/-/beet-0.7.2.tgz#fa4726e4cfd4fb6fed6cddc9b5213c1c2a2d0b77"
-  integrity sha512-K+g3WhyFxKPc0xIvcIjNyV1eaTVJTiuaHZpig7Xx0MuYRMoJLLvhLTnUXhFdR5Tu2l2QSyKwfyXDgZlzhULqFg==
-  dependencies:
-    ansicolors "^0.3.2"
-    assert "^2.1.0"
-    bn.js "^5.2.0"
-    debug "^4.3.3"
-
-"@metaplex-foundation/beet@^0.4.0":
-  version "0.4.0"
-  resolved "https://registry.yarnpkg.com/@metaplex-foundation/beet/-/beet-0.4.0.tgz#eb2a0a6eb084bb25d67dd9bed2f7387ee7e63a55"
-  integrity sha512-2OAKJnLatCc3mBXNL0QmWVQKAWK2C7XDfepgL0p/9+8oSx4bmRAFHFqptl1A/C0U5O3dxGwKfmKluW161OVGcA==
-  dependencies:
-    ansicolors "^0.3.2"
-    bn.js "^5.2.0"
-    debug "^4.3.3"
-
-"@metaplex-foundation/rustbin@^0.3.0", "@metaplex-foundation/rustbin@^0.3.1":
-  version "0.3.5"
-  resolved "https://registry.yarnpkg.com/@metaplex-foundation/rustbin/-/rustbin-0.3.5.tgz#56d028afd96c2b56ad3bbea22ff454adde900e8c"
-  integrity sha512-m0wkRBEQB/8krwMwKBvFugufZtYwMXiGHud2cTDAv+aGXK4M90y0Hx67/wpu+AqqoQfdV8VM9YezUOHKD+Z5kA==
-  dependencies:
-    debug "^4.3.3"
-    semver "^7.3.7"
-    text-table "^0.2.0"
-    toml "^3.0.0"
-
-"@metaplex-foundation/solita@^0.12.2":
-  version "0.12.2"
-  resolved "https://registry.yarnpkg.com/@metaplex-foundation/solita/-/solita-0.12.2.tgz#13ef213ac183c986f6d01c5d981c44e59a900834"
-  integrity sha512-oczMfE43NNHWweSqhXPTkQBUbap/aAiwjDQw8zLKNnd/J8sXr/0+rKcN5yJIEgcHeKRkp90eTqkmt2WepQc8yw==
-  dependencies:
-    "@metaplex-foundation/beet" "^0.4.0"
-    "@metaplex-foundation/beet-solana" "^0.3.0"
-    "@metaplex-foundation/rustbin" "^0.3.0"
-    "@solana/web3.js" "^1.36.0"
-    camelcase "^6.2.1"
-    debug "^4.3.3"
-    js-sha256 "^0.9.0"
-    prettier "^2.5.1"
-    snake-case "^3.0.4"
-    spok "^1.4.3"
-
-"@msgpack/msgpack@^3.1.2":
-  version "3.1.3"
-  resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-3.1.3.tgz#c4bff2b9539faf0882f3ee03537a7e9a4b3a7864"
-  integrity sha512-47XIizs9XZXvuJgoaJUIE2lFoID8ugvc0jzSHP+Ptfk8nTbnR8g788wv48N03Kx0UkAv559HWRQ3yzOgzlRNUA==
+"@msgpack/msgpack@3.1.2":
+  version "3.1.2"
+  resolved "https://registry.yarnpkg.com/@msgpack/msgpack/-/msgpack-3.1.2.tgz#fdd25cc2202297519798bbaf4689152ad9609e19"
+  integrity sha512-JEW4DEtBzfe8HvUYecLU9e6+XJnKDlUAIve8FvPzF3Kzs6Xo/KuZkZJsDH0wJXl/qEZbeeE7edxDNY3kMs39hQ==
 
 "@noble/curves@^1.4.2":
   version "1.9.2"
@@ -2068,16 +1860,6 @@
   dependencies:
     "@nodelib/fs.scandir" "2.1.5"
     fastq "^1.6.0"
-
-"@openbook-dex/openbook-v2@0.2.10":
-  version "0.2.10"
-  resolved "https://registry.yarnpkg.com/@openbook-dex/openbook-v2/-/openbook-v2-0.2.10.tgz#a5cfcd30ce827ecd446b76429a5e41baa23a318c"
-  integrity sha512-JOroVQHeia+RbghpluDJB5psUIhdhYRPLu0zWoG0h5vgDU4SjXwlcC+LJiIa2HVPasvZjWuCtlKWFyrOS75lOA==
-  dependencies:
-    "@coral-xyz/anchor" "^0.29.0"
-    "@solana/spl-token" "^0.4.0"
-    "@solana/web3.js" "^1.77.3"
-    big.js "^6.2.1"
 
 "@opentelemetry/api-metrics@0.29.2":
   version "0.29.2"
@@ -2613,7 +2395,7 @@
     bn.js "^5.1.2"
     buffer-layout "^1.2.0"
 
-"@project-serum/serum@0.13.65", "@project-serum/serum@^0.13.65":
+"@project-serum/serum@^0.13.65":
   version "0.13.65"
   resolved "https://registry.yarnpkg.com/@project-serum/serum/-/serum-0.13.65.tgz#6d3cf07912f13985765237f053cca716fe84b0b0"
   integrity sha512-BHRqsTqPSfFB5p+MgI2pjvMBAQtO8ibTK2fYY96boIFkCI3TTwXDt2gUmspeChKO2pqHr5aKevmexzAcXxrSRA==
@@ -2809,35 +2591,6 @@
   integrity sha512-V4BG07kuYSUkTCSBHG8G8TNhM+F19jXFWnQtzj+we8DrkpSBCee9Z3Ms8yiGer/dlmhe35/Xdgyo3/0rQKg7YA==
   dependencies:
     "@sinonjs/commons" "^3.0.0"
-
-"@slack/logger@^3.0.0":
-  version "3.0.0"
-  resolved "https://registry.yarnpkg.com/@slack/logger/-/logger-3.0.0.tgz#b736d4e1c112c22a10ffab0c2d364620aedcb714"
-  integrity sha512-DTuBFbqu4gGfajREEMrkq5jBhcnskinhr4+AnfJEk48zhVeEv3XnUKGIX98B74kxhYsIMfApGGySTn7V3b5yBA==
-  dependencies:
-    "@types/node" ">=12.0.0"
-
-"@slack/types@^2.0.0":
-  version "2.15.0"
-  resolved "https://registry.yarnpkg.com/@slack/types/-/types-2.15.0.tgz#c277c39545d4d06301279cdec0fe4ecfc899e0e9"
-  integrity sha512-livb1gyG3J8ATLBJ3KjZfjHpTRz9btY1m5cgNuXxWJbhwRB1Gwb8Ly6XLJm2Sy1W6h+vLgqIHg7IwKrF1C1Szg==
-
-"@slack/web-api@6.4.0":
-  version "6.4.0"
-  resolved "https://registry.yarnpkg.com/@slack/web-api/-/web-api-6.4.0.tgz#fe8212e4aca50c4cbafe4dac3f4b81c84c527423"
-  integrity sha512-Hi0pq60d/zCqn1UQvuSyrMcoLGNbKUBL/Tmk1b1RPTZdVYiRK8zp337glvhxTBwiaGOu+58uO5yflpK1AAuoRw==
-  dependencies:
-    "@slack/logger" "^3.0.0"
-    "@slack/types" "^2.0.0"
-    "@types/is-stream" "^1.1.0"
-    "@types/node" ">=12.0.0"
-    axios "^0.21.1"
-    eventemitter3 "^3.1.0"
-    form-data "^2.5.0"
-    is-electron "^2.2.0"
-    is-stream "^1.1.0"
-    p-queue "^6.6.1"
-    p-retry "^4.0.0"
 
 "@smithy/abort-controller@^4.0.4":
   version "4.0.4"
@@ -3695,7 +3448,7 @@
   resolved "https://registry.yarnpkg.com/@solana-program/system/-/system-0.7.0.tgz#3e21c9fb31d3795eb65ba5cb663947c19b305bad"
   integrity sha512-FKTBsKHpvHHNc1ATRm7SlC5nF/VdJtOSjldhcyfMN9R7xo712Mo2jHIzvBgn8zQO5Kg0DcWuKB7268Kv1ocicw==
 
-"@solana-program/token-2022@^0.4.2":
+"@solana-program/token-2022@^0.4.1":
   version "0.4.2"
   resolved "https://registry.yarnpkg.com/@solana-program/token-2022/-/token-2022-0.4.2.tgz#f90a638de82acb7933a114e884a24ac4be8ef635"
   integrity sha512-zIpR5t4s9qEU3hZKupzIBxJ6nUV5/UVyIT400tu9vT1HMs5JHxaTTsb5GUhYjiiTvNwU0MQavbwc4Dl29L0Xvw==
@@ -3963,7 +3716,7 @@
     "@solana/errors" "5.1.0"
     "@solana/nominal-types" "5.1.0"
 
-"@solana/kit@^2.3.0":
+"@solana/kit@^2.1.1":
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/@solana/kit/-/kit-2.3.0.tgz#92deb7c4883293617209aecac9a43d5e41ccf092"
   integrity sha512-sb6PgwoW2LjE5oTFu4lhlS/cGt/NB3YrShEyx7JgWFWysfgLdJnhwWThgwy/4HjNsmtMrQGWVls0yVBHcMvlMQ==
@@ -4244,26 +3997,28 @@
   dependencies:
     "@solana/codecs" "2.0.0-rc.1"
 
-"@solana/spl-token-metadata@^0.1.2", "@solana/spl-token-metadata@^0.1.6":
+"@solana/spl-token-metadata@^0.1.6":
   version "0.1.6"
   resolved "https://registry.yarnpkg.com/@solana/spl-token-metadata/-/spl-token-metadata-0.1.6.tgz#d240947aed6e7318d637238022a7b0981b32ae80"
   integrity sha512-7sMt1rsm/zQOQcUWllQX9mD2O6KhSAtY1hFR2hfFwgqfFWzSY9E9GDvFVNYUI1F0iQKcm6HmePU9QbKRXTEBiA==
   dependencies:
     "@solana/codecs" "2.0.0-rc.1"
 
-"@solana/spl-token@0.3.8":
-  version "0.3.8"
-  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.3.8.tgz#8e9515ea876e40a4cc1040af865f61fc51d27edf"
-  integrity sha512-ogwGDcunP9Lkj+9CODOWMiVJEdRtqHAtX2rWF62KxnnSWtMZtV9rDhTrZFshiyJmxDnRL/1nKE1yJHg4jjs3gg==
-  dependencies:
-    "@solana/buffer-layout" "^4.0.0"
-    "@solana/buffer-layout-utils" "^0.2.0"
-    buffer "^6.0.3"
-
-"@solana/spl-token@0.4.13", "@solana/spl-token@^0.4.0":
+"@solana/spl-token@0.4.13":
   version "0.4.13"
   resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.4.13.tgz#8f65c3c2b315e1a00a91b8d0f60922c6eb71de62"
   integrity sha512-cite/pYWQZZVvLbg5lsodSovbetK/eA24gaR0eeUeMuBAMNrT8XFCwaygKy0N2WSg3gSyjjNpIeAGBAKZaY/1w==
+  dependencies:
+    "@solana/buffer-layout" "^4.0.0"
+    "@solana/buffer-layout-utils" "^0.2.0"
+    "@solana/spl-token-group" "^0.0.7"
+    "@solana/spl-token-metadata" "^0.1.6"
+    buffer "^6.0.3"
+
+"@solana/spl-token@0.4.14":
+  version "0.4.14"
+  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.4.14.tgz#b86bc8a17f50e9680137b585eca5f5eb9d55c025"
+  integrity sha512-u09zr96UBpX4U685MnvQsNzlvw9TiY005hk1vJmJr7gMJldoPG1eYU5/wNEyOA5lkMLiR/gOi9SFD4MefOYEsA==
   dependencies:
     "@solana/buffer-layout" "^4.0.0"
     "@solana/buffer-layout-utils" "^0.2.0"
@@ -4282,16 +4037,6 @@
     buffer "6.0.3"
     buffer-layout "^1.2.0"
     dotenv "10.0.0"
-
-"@solana/spl-token@^0.3.7":
-  version "0.3.11"
-  resolved "https://registry.yarnpkg.com/@solana/spl-token/-/spl-token-0.3.11.tgz#cdc10f9472b29b39c8983c92592cadd06627fb9a"
-  integrity sha512-bvohO3rIMSVL24Pb+I4EYTJ6cL82eFpInEXD/I8K8upOGjpqHsKUoAempR/RnUlI1qSFNyFlWJfu6MNUgfbCQQ==
-  dependencies:
-    "@solana/buffer-layout" "^4.0.0"
-    "@solana/buffer-layout-utils" "^0.2.0"
-    "@solana/spl-token-metadata" "^0.1.2"
-    buffer "^6.0.3"
 
 "@solana/subscribable@2.3.0":
   version "2.3.0"
@@ -4392,7 +4137,7 @@
     "@solana/rpc-types" "5.1.0"
     "@solana/transaction-messages" "5.1.0"
 
-"@solana/web3.js@1.98.0", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.30.2", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.36.0", "@solana/web3.js@^1.56.2", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.69.0", "@solana/web3.js@^1.77.3", "@solana/web3.js@^1.98.0", "@solana/web3.js@^1.98.2":
+"@solana/web3.js@1.98.0", "@solana/web3.js@^1.17.0", "@solana/web3.js@^1.21.0", "@solana/web3.js@^1.30.2", "@solana/web3.js@^1.32.0", "@solana/web3.js@^1.68.0", "@solana/web3.js@^1.69.0":
   version "1.98.0"
   resolved "https://registry.yarnpkg.com/@solana/web3.js/-/web3.js-1.98.0.tgz#21ecfe8198c10831df6f0cfde7f68370d0405917"
   integrity sha512-nz3Q5OeyGFpFCR+erX2f6JPt3sKhzhYcSycBCSPkWjzSVDh/Rr1FqTVMRe58FKO16/ivTUcuJjeS5MyBvpkbzA==
@@ -4420,52 +4165,6 @@
   dependencies:
     tslib "^2.8.0"
 
-"@switchboard-xyz/common@3.0.14":
-  version "3.0.14"
-  resolved "https://registry.yarnpkg.com/@switchboard-xyz/common/-/common-3.0.14.tgz#5b363995bd0fefa22198286992dbe54f3e544b08"
-  integrity sha512-LpxzEywO0DjPYIgPzQYkf32C7agwW4YRsPN6BcIvYrw0iJdDMtPZ3SQfIGHLSlD1fwvn2KLUYuGaKegeq4aBTw==
-  dependencies:
-    "@solana/web3.js" "^1.98.0"
-    axios "^1.8.3"
-    big.js "^6.2.2"
-    bn.js "^5.2.1"
-    bs58 "^6.0.0"
-    buffer "^6.0.3"
-    decimal.js "^10.4.3"
-    js-sha256 "^0.11.0"
-    protobufjs "^7.4.0"
-    yaml "^2.6.1"
-
-"@switchboard-xyz/common@>=3.0.0":
-  version "3.4.1"
-  resolved "https://registry.yarnpkg.com/@switchboard-xyz/common/-/common-3.4.1.tgz#3144c0730649e60129ea8c9b3c04062ceff35c6e"
-  integrity sha512-TropBlBYuDeBnmGHkPSmgC3clLqAxy51ZGbwk4ejAgadnszWOgYHcH7taRG4Ha17DYSCWw/LGMBKbunGo+Aoaw==
-  dependencies:
-    "@solana/web3.js" "^1.98.2"
-    axios "^1.9.0"
-    big.js "^6.2.2"
-    bn.js "^5.2.1"
-    bs58 "^6.0.0"
-    buffer "^6.0.3"
-    decimal.js "^10.4.3"
-    js-sha256 "^0.11.0"
-    protobufjs "^7.4.0"
-    yaml "^2.6.1"
-    zod "4.0.0-beta.20250505T195954"
-
-"@switchboard-xyz/on-demand@2.4.1":
-  version "2.4.1"
-  resolved "https://registry.yarnpkg.com/@switchboard-xyz/on-demand/-/on-demand-2.4.1.tgz#3db64b0596d9daa0b010ee44193d5512e0ba512d"
-  integrity sha512-eSlBp+c8lxpcSgh0/2xK8OaLHPziTSZlcs8V96gZGdiCJz1KgWJRNE1qnIJDOwaGdFecZdwcmajfQRtLRLED3w==
-  dependencies:
-    "@coral-xyz/anchor-30" "npm:@coral-xyz/anchor@0.30.1"
-    "@isaacs/ttlcache" "^1.4.1"
-    "@switchboard-xyz/common" ">=3.0.0"
-    axios "^1.8.3"
-    bs58 "^6.0.0"
-    buffer "^6.0.3"
-    js-yaml "^4.1.0"
-
 "@triton-one/yellowstone-grpc-napi-darwin-arm64@0.0.10":
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/@triton-one/yellowstone-grpc-napi-darwin-arm64/-/yellowstone-grpc-napi-darwin-arm64-0.0.10.tgz#17d3f1cfccff393ebfcd4afffe2c9445fd63b41e"
@@ -4485,13 +4184,6 @@
   version "0.0.10"
   resolved "https://registry.yarnpkg.com/@triton-one/yellowstone-grpc-napi-linux-x64-musl/-/yellowstone-grpc-napi-linux-x64-musl-0.0.10.tgz#53d0e864ccc208c11413e9fe33a3a7bb7f3ecd71"
   integrity sha512-Y3KlvcCy59xIqQYk/HpRSKCyCY83hEWg6bzOZ1k7+vyy7zfLwNW6rK5BkdHSezk2rJU9gTeduKvcq1P8ixJYbg==
-
-"@triton-one/yellowstone-grpc@1.4.1":
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/@triton-one/yellowstone-grpc/-/yellowstone-grpc-1.4.1.tgz#b50434f68c3d73c6ce3e1f225656064c080f4b25"
-  integrity sha512-ZN49vooxFbOqWttll8u7AOsIVnX+srqX9ddhZ9ttE+OcehUo8c2p2suK8Gr2puab49cgsV0VGjiTn9Gua/ntIw==
-  dependencies:
-    "@grpc/grpc-js" "^1.8.0"
 
 "@triton-one/yellowstone-grpc@5.0.5":
   version "5.0.5"
@@ -4749,13 +4441,6 @@
   dependencies:
     "@types/node" "*"
 
-"@types/is-stream@^1.1.0":
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/@types/is-stream/-/is-stream-1.1.0.tgz#b84d7bb207a210f2af9bed431dc0fbe9c4143be1"
-  integrity sha512-jkZatu4QVbR60mpIzjINmtS1ZF4a/FqdTUTBeQDVOQ2PYyidtwFKr0B5G6ERukKwliq+7mIXvxyppwzG5EgRYg==
-  dependencies:
-    "@types/node" "*"
-
 "@types/istanbul-lib-coverage@*", "@types/istanbul-lib-coverage@^2.0.0", "@types/istanbul-lib-coverage@^2.0.1":
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/@types/istanbul-lib-coverage/-/istanbul-lib-coverage-2.0.6.tgz#7739c232a1fee9b4d3ce8985f314c0c6d33549d7"
@@ -4872,7 +4557,7 @@
   dependencies:
     "@types/node" "*"
 
-"@types/node@*", "@types/node@>=12.0.0", "@types/node@>=13.7.0":
+"@types/node@*", "@types/node@>=13.7.0":
   version "24.0.14"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-24.0.14.tgz#6e3d4fb6d858c48c69707394e1a0e08ce1ecc1bc"
   integrity sha512-4zXMWD91vBLGRtHK3YbIoFMia+1nqEz72coM42C5ETjnNCa/heoj7NT1G67iAfOqMmcfhuCZ4uNpyz8EjlAejw==
@@ -4883,13 +4568,6 @@
   version "12.20.55"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-12.20.55.tgz#c329cbd434c42164f846b909bd6f85b5537f6240"
   integrity sha512-J8xLz7q2OFulZ2cyGTLE1TbbZcjpno7FaN6zdJNrgAdrJ+DZzh/uFR6YrTb4C+nXakvud8Q4+rbhoIWlYQbUFQ==
-
-"@types/node@^18.11.13":
-  version "18.19.119"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-18.19.119.tgz#e7c2098b8c0243af0005503a6d5da92e0d989c84"
-  integrity sha512-d0F6m9itIPaKnrvEMlzE48UjwZaAnFW7Jwibacw9MNdqadjKNpUm9tfJYDwmShJmgqcoqYUX3EMKO1+RWiuuNg==
-  dependencies:
-    undici-types "~5.26.4"
 
 "@types/pg-pool@2.0.3":
   version "2.0.3"
@@ -4954,11 +4632,6 @@
   dependencies:
     "@types/bunyan" "*"
     "@types/node" "*"
-
-"@types/retry@0.12.0":
-  version "0.12.0"
-  resolved "https://registry.yarnpkg.com/@types/retry/-/retry-0.12.0.tgz#2b35eccfcee7d38cd72ad99232fbd58bffb3c84d"
-  integrity sha512-wWKOClTTiizcZhXnPY4wikVAwmdYHp8q6DmC+EJUzAMsycb7HB32Kh9RN4+0gExjmPmZSAQjgURXIGATPegAvA==
 
 "@types/semver@^7.5.0":
   version "7.7.0"
@@ -5114,10 +4787,54 @@
   resolved "https://registry.yarnpkg.com/@ungap/structured-clone/-/structured-clone-1.3.0.tgz#d06bbb384ebcf6c505fde1c3d0ed4ddffe0aaff8"
   integrity sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g==
 
-"@zod/core@0.11.6":
-  version "0.11.6"
-  resolved "https://registry.yarnpkg.com/@zod/core/-/core-0.11.6.tgz#9216e98848dc9364eda35e3da90f5362f10e8887"
-  integrity sha512-03Bv82fFSfjDAvMfdHHdGSS6SOJs0iCcJlWJv1kJHRtoTT02hZpyip/2Lk6oo4l4FtjuwTrsEQTwg/LD8I7dJA==
+"@velocity-exchange/common@0.0.1":
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/@velocity-exchange/common/-/common-0.0.1.tgz#7b1ba4069c2d5e34fb0d04104627193acb5a75c0"
+  integrity sha512-nPq7G92YdRhKxHMeWuzr3Zljps6MnGtrNuoLuEw6oqR/reTLOcHg74fgyCEgYUwgVMvYLjMpDBSZWtgMa5IAvQ==
+  dependencies:
+    "@solana/spl-token" "0.4.14"
+    "@solana/web3.js" "1.98.0"
+    "@velocity-exchange/sdk" "0.0.1"
+    bcryptjs-react "2.4.6"
+    cerializr "3.1.4"
+    dotenv "17.4.2"
+    immer "10.0.3"
+    ioredis "5.4.1"
+    isomorphic-ws "5.0.0"
+    localstorage-memory "1.0.3"
+    rxjs "7.8.2"
+    tiny-invariant "1.3.1"
+    tweetnacl "1.0.3"
+
+"@velocity-exchange/sdk@0.0.1", "@velocity-exchange/sdk@0.0.3":
+  version "0.0.3"
+  resolved "https://registry.yarnpkg.com/@velocity-exchange/sdk/-/sdk-0.0.3.tgz#e15f910e6564aea8b37f32e0f43127267ed93edd"
+  integrity sha512-n1CYqk7UCJeMm+nC8DCSiHozVYOunWY8JqXtxfFOA8WTivi81w0iFMTxPS29hswWrBqejpiOEG79tJ8tHaMafQ==
+  dependencies:
+    "@anchor-lang/core" "1.0.1"
+    "@coral-xyz/anchor" "npm:@anchor-lang/core@1.0.1"
+    "@coral-xyz/anchor-29" "npm:@coral-xyz/anchor@0.29.0"
+    "@msgpack/msgpack" "3.1.2"
+    "@pythnetwork/client" "2.5.3"
+    "@pythnetwork/price-service-sdk" "1.7.1"
+    "@pythnetwork/pyth-lazer-sdk" "6.0.0"
+    "@solana/spl-token" "0.4.13"
+    "@solana/web3.js" "1.98.0"
+    "@triton-one/yellowstone-grpc" "5.0.5"
+    anchor-bankrun "0.5.0"
+    gill "0.10.2"
+    nanoid "3.3.4"
+    node-cache "5.1.2"
+    solana-bankrun "0.4.0"
+    strict-event-emitter-types "2.0.0"
+    tweetnacl "1.0.3"
+    tweetnacl-util "0.15.1"
+    uuid "8.3.2"
+    yargs "17.7.2"
+    zod "4.0.17"
+    zstddec "0.1.0"
+  optionalDependencies:
+    helius-laserstream "0.1.8"
 
 "@zodios/core@^10.9.6":
   version "10.9.6"
@@ -5181,11 +4898,6 @@ ajv@^8.1.0:
     json-schema-traverse "^1.0.0"
     require-from-string "^2.0.2"
 
-anchor-bankrun@0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/anchor-bankrun/-/anchor-bankrun-0.3.0.tgz#3789fcecbc201a2334cff228b99cc0da8ef0167e"
-  integrity sha512-PYBW5fWX+iGicIS5MIM/omhk1tQPUc0ELAnI/IkLKQJ6d75De/CQRh8MF2bU/TgGyFi6zEel80wUe3uRol9RrQ==
-
 anchor-bankrun@0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/anchor-bankrun/-/anchor-bankrun-0.5.0.tgz#62b5905f6f0ed3799d4a37e6be045887c13d4f33"
@@ -5214,11 +4926,6 @@ ansi-styles@^5.0.0:
   version "5.2.0"
   resolved "https://registry.yarnpkg.com/ansi-styles/-/ansi-styles-5.2.0.tgz#07449690ad45777d1924ac2abb2fc8895dba836b"
   integrity sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==
-
-ansicolors@^0.3.2, ansicolors@~0.3.2:
-  version "0.3.2"
-  resolved "https://registry.yarnpkg.com/ansicolors/-/ansicolors-0.3.2.tgz#665597de86a9ffe3aa9bfbe6cae5c6ea426b4979"
-  integrity sha512-QXu7BPrP29VllRxH8GwB7x5iX5qWKAAMLqKQGWTeLWVlNHNOpVMJ91dsxQAIWXpjuW5wqvxu3Jd/nRjrJ+0pqg==
 
 anymatch@^3.0.3:
   version "3.1.3"
@@ -5260,7 +4967,7 @@ array-union@^2.1.0:
   resolved "https://registry.yarnpkg.com/array-union/-/array-union-2.1.0.tgz#b798420adbeb1de828d84acd8a2e23d3efe85e8d"
   integrity sha512-HGyxoOTYUyCM6stUe6EJgnd4EoewAI7zMdfqO+kGjnlZmBDz/cR5pf8r/cR4Wq60sL/p0IkcjUEEPwS3GFrIyw==
 
-assert@^2.0.0, assert@^2.1.0:
+assert@^2.0.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/assert/-/assert-2.1.0.tgz#6d92a238d05dc02e7427c881fb8be81c8448b2dd"
   integrity sha512-eLHpSK/Y4nhMJ07gDaAzoX/XAKS8PSaojml3M0DM4JpV1LAi5JOJ/p6H/XWrl8L+DzVEvVCW1z3vWAaB9oTsQw==
@@ -5310,14 +5017,7 @@ avvio@^7.1.2:
     fastq "^1.6.1"
     queue-microtask "^1.1.2"
 
-axios@^0.21.1:
-  version "0.21.4"
-  resolved "https://registry.yarnpkg.com/axios/-/axios-0.21.4.tgz#c67b90dc0568e5c1cf2b0b858c43ba28e2eda575"
-  integrity sha512-ut5vewkiu8jjGBdqpM44XxjuCjq9LAKeHVmoVfHVzy8eHgxxq8SbAVQNovDA8mVi05kP0Ea/n/UzcSHcTJQfNg==
-  dependencies:
-    follow-redirects "^1.14.0"
-
-axios@^1.6.2, axios@^1.6.8, axios@^1.8.3, axios@^1.9.0:
+axios@^1.6.2:
   version "1.10.0"
   resolved "https://registry.yarnpkg.com/axios/-/axios-1.10.0.tgz#af320aee8632eaf2a400b6a1979fa75856f38d54"
   integrity sha512-/1xYAC4MP/HEG+3duIhFr4ZQXR4sQXOIe+o6sdqzeykGLx6Upp/1p8MHqhINOvGeP7xyNHe7tsiJByc4SSVUxw==
@@ -5401,16 +5101,6 @@ base-x@^3.0.2:
   dependencies:
     safe-buffer "^5.0.1"
 
-base-x@^4.0.0:
-  version "4.0.1"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-4.0.1.tgz#817fb7b57143c501f649805cb247617ad016a885"
-  integrity sha512-uAZ8x6r6S3aUM9rbHGVOIsR15U/ZSc82b3ymnCPsT45Gk1DDvhDPdIgB5MrhirZWt+5K0EEPQH985kNqZgNPFw==
-
-base-x@^5.0.0:
-  version "5.0.1"
-  resolved "https://registry.yarnpkg.com/base-x/-/base-x-5.0.1.tgz#16bf35254be1df8aca15e36b7c1dda74b2aa6b03"
-  integrity sha512-M7uio8Zt++eg3jPj+rHMfCC+IuygQHHCOU+IYsVtik6FWjuYpVt/+MRKcgsAMHh8mMFAwnB+Bs+mTrFiXjMzKg==
-
 base64-js@^1.3.1, base64-js@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/base64-js/-/base64-js-1.5.1.tgz#1b1b440160a5bf7ad40b650f095963481903930a"
@@ -5427,11 +5117,6 @@ bcryptjs-react@2.4.6:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/bcryptjs-react/-/bcryptjs-react-2.4.6.tgz#493be46586f2eaaf17efd142feea617169c26881"
   integrity sha512-dc9oUX1JwnXoSwIXL6T4p/MxPvu2AHlhmml3vA4mA/z492j3vtJl29jLylYyYtPw3OHii3gGmdNM9kYeq7ZrqA==
-
-big.js@^6.2.1, big.js@^6.2.2:
-  version "6.2.2"
-  resolved "https://registry.yarnpkg.com/big.js/-/big.js-6.2.2.tgz#be3bb9ac834558b53b099deef2a1d06ac6368e1a"
-  integrity sha512-y/ie+Faknx7sZA5MfGA2xKlu0GDv8RWrXGsmlteyJQ2lvoKv9GBK/fpRMc2qlSoBAgNxrixICFCBefIq8WCQpQ==
 
 bigint-buffer@^1.1.5:
   version "1.1.5"
@@ -5540,20 +5225,6 @@ bs58@^4.0.0, bs58@^4.0.1:
   dependencies:
     base-x "^3.0.2"
 
-bs58@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/bs58/-/bs58-5.0.0.tgz#865575b4d13c09ea2a84622df6c8cbeb54ffc279"
-  integrity sha512-r+ihvQJvahgYT50JD05dyJNKlmmSlMoOGwn1lCcEzanPglg7TxYjioQUYehQ9mAR/+hOSd2jRc/Z2y5UxBymvQ==
-  dependencies:
-    base-x "^4.0.0"
-
-bs58@^6.0.0:
-  version "6.0.0"
-  resolved "https://registry.yarnpkg.com/bs58/-/bs58-6.0.0.tgz#a2cda0130558535dd281a2f8697df79caaf425d8"
-  integrity sha512-PD0wEnEYg6ijszw/u8s+iI3H17cTymlrwkKhDhPZq+Sokl3AU4htyBFTjAeNAlCCmg0f53g6ih3jATyCKftTfw==
-  dependencies:
-    base-x "^5.0.0"
-
 bser@2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/bser/-/bser-2.1.1.tgz#e6787da20ece9d07998533cfd9de6f5c38f4bc05"
@@ -5632,7 +5303,7 @@ camelcase@^5.3.1:
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-5.3.1.tgz#e3c9b31569e106811df242f715725a1f4c494320"
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
-camelcase@^6.2.0, camelcase@^6.2.1, camelcase@^6.3.0:
+camelcase@^6.2.0, camelcase@^6.3.0:
   version "6.3.0"
   resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.3.0.tgz#5685b95eb209ac9c0c177467778c9c84df58ba9a"
   integrity sha512-Gmy6FhYlCY7uOElZUSbxo2UCDH8owEk996gkbrpsgGtrJLM3J7jGxl9Ic7Qwwj4ivOE5AWZWRMecDdF7hqGjFA==
@@ -5655,7 +5326,7 @@ chalk@5.6.2:
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-5.6.2.tgz#b1238b6e23ea337af71c7f8a295db5af0c158aea"
   integrity sha512-7NzBL0rN6fMUW+f7A6Io4h40qQlG+xGmtMxfbnH/K7TAtt8JQWVQK+6g0UXKMeVJoyV5EkkNsErQ8pVD3bLHbA==
 
-chalk@^4.0.0, chalk@^4.0.2, chalk@~4.1.2:
+chalk@^4.0.0, chalk@^4.0.2:
   version "4.1.2"
   resolved "https://registry.yarnpkg.com/chalk/-/chalk-4.1.2.tgz#aac4e2b7734a740867aeb16bf02aad556a1e7a01"
   integrity sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==
@@ -5908,7 +5579,7 @@ debug@2.6.9:
   dependencies:
     ms "2.0.0"
 
-debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.3, debug@^4.3.4:
+debug@^4.0.0, debug@^4.1.0, debug@^4.1.1, debug@^4.3.1, debug@^4.3.2, debug@^4.3.4:
   version "4.4.1"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.4.1.tgz#e5a8bc6cbc4c6cd3e64308b0693a3d4fa550189b"
   integrity sha512-KcKCqiftBJcZr++7ykoDIEwSa3XWowTfNPo92BYxjXiyYEVrUQh2aLyhxBCwww+heortUFxEJYcRzosstTEBYQ==
@@ -5921,11 +5592,6 @@ debug@~4.3.1:
   integrity sha512-Er2nc/H7RrMXZBFCEim6TCmMk02Z8vLC2Rbi1KEBggpo0fS6l0S1nnapwmIi3yW/+GOJap1Krg4w0Hg80oCqgQ==
   dependencies:
     ms "^2.1.3"
-
-decimal.js@^10.4.3:
-  version "10.6.0"
-  resolved "https://registry.yarnpkg.com/decimal.js/-/decimal.js-10.6.0.tgz#e649a43e3ab953a72192ff5983865e509f37ed9a"
-  integrity sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==
 
 dedent@^1.0.0:
   version "1.6.0"
@@ -6032,10 +5698,10 @@ dotenv@10.0.0, dotenv@^10.0.0:
   resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-10.0.0.tgz#3d4227b8fb95f81096cdd2b66653fb2c7085ba81"
   integrity sha512-rlBi9d8jpv9Sf1klPjNfFAuWDjKLwTIJJ/VxtoTwIR6hnZxcEOQCZg2oIL3MWBYw5GpUDKOEnND7LXTbIpQ03Q==
 
-dotenv@^17.2.2:
-  version "17.2.3"
-  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.2.3.tgz#ad995d6997f639b11065f419a22fabf567cdb9a2"
-  integrity sha512-JVUnt+DUIzu87TABbhPmNfVdBDt18BLOWjMUFJMSi/Qqg7NTYtabbvSNJGOJ7afbRuv9D/lngizHtP7QyLQ+9w==
+dotenv@17.4.2:
+  version "17.4.2"
+  resolved "https://registry.yarnpkg.com/dotenv/-/dotenv-17.4.2.tgz#c07e54a746e11eba021dd9e1047ced5afdc1c034"
+  integrity sha512-nI4U3TottKAcAD9LLud4Cb7b2QztQMUEfHbvhTH09bqXTxnSie8WnjPALV/WMCrJZ6UV/qHJ6L03OqO3LcdYZw==
 
 dunder-proto@^1.0.1:
   version "1.0.1"
@@ -6314,12 +5980,7 @@ etag@~1.8.1:
   resolved "https://registry.yarnpkg.com/etag/-/etag-1.8.1.tgz#41ae2eeb65efa62268aebfea83ac7d79299b0887"
   integrity sha512-aIL5Fx7mawVa300al2BnEE4iNvo1qETxLrPI/o05L7z6go7fCw1J6EQmbK4FmJ2AS7kgVF/KEZWufBfdClMcPg==
 
-eventemitter3@^3.1.0:
-  version "3.1.2"
-  resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-3.1.2.tgz#2d3d48f9c346698fce83a85d7d664e98535df6e7"
-  integrity sha512-tvtQIeLVHjDkJYnzf2dgVMxfuSGJeM/7UCG17TT4EumTfNtF+0nebF/4zWOIkCreAbtNqhGEboB6BWrwqNaw4Q==
-
-eventemitter3@^4.0.4, eventemitter3@^4.0.7:
+eventemitter3@^4.0.7:
   version "4.0.7"
   resolved "https://registry.yarnpkg.com/eventemitter3/-/eventemitter3-4.0.7.tgz#2de9b68f6528d5644ef5c59526a1b4a07306169f"
   integrity sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==
@@ -6582,15 +6243,6 @@ find-my-way@^4.5.0:
     safe-regex2 "^2.0.0"
     semver-store "^0.3.0"
 
-find-process@^1.4.7:
-  version "1.4.11"
-  resolved "https://registry.yarnpkg.com/find-process/-/find-process-1.4.11.tgz#f7246251d396b35b9ae41fff7b87137673567fcc"
-  integrity sha512-mAOh9gGk9WZ4ip5UjV0o6Vb4SrfnAmtsFNzkMRH9HQiFXVQnDyQFrSHTK5UoG6E+KV+s+cIznbtwpfN41l2nFA==
-  dependencies:
-    chalk "~4.1.2"
-    commander "^12.1.0"
-    loglevel "^1.9.2"
-
 find-up@^4.0.0, find-up@^4.1.0:
   version "4.1.0"
   resolved "https://registry.yarnpkg.com/find-up/-/find-up-4.1.0.tgz#97afe7d6cdc0bc5928584b7c8d7b16e8a9aa5d19"
@@ -6638,7 +6290,7 @@ fn.name@1.x.x:
   resolved "https://registry.yarnpkg.com/fn.name/-/fn.name-1.1.0.tgz#26cad8017967aea8731bc42961d04a3d5988accc"
   integrity sha512-GRnmB5gPyJpAhTQdSZTSp9uaPSvl09KoYcMQtsB9rQoOmzs9dH6ffeccH+Z+cv6P68Hu5bC6JjRh4Ah/mHSNRw==
 
-follow-redirects@^1.14.0, follow-redirects@^1.15.6:
+follow-redirects@^1.15.6:
   version "1.15.9"
   resolved "https://registry.yarnpkg.com/follow-redirects/-/follow-redirects-1.15.9.tgz#a604fa10e443bf98ca94228d9eebcc2e8a2c8ee1"
   integrity sha512-gew4GsXizNgdoRyqmyfMHyAmXsZDk6mHkSxZFCzW9gwlbtOW44CDtYavM+y+72qD/Vq2l550kMF52DT8fOLJqQ==
@@ -6649,17 +6301,6 @@ for-each@^0.3.5:
   integrity sha512-dKx12eRCVIzqCxFGplyFKJMPvLEWgmNtUrpTiJIR5u97zEhRG8ySrtboPHZXx7daLxQVrl643cTzbab2tkQjxg==
   dependencies:
     is-callable "^1.2.7"
-
-form-data@^2.5.0:
-  version "2.5.3"
-  resolved "https://registry.yarnpkg.com/form-data/-/form-data-2.5.3.tgz#f9bcf87418ce748513c0c3494bb48ec270c97acc"
-  integrity sha512-XHIrMD0NpDrNM/Ckf7XJiBbLl57KEhT3+i3yY+eWm+cqYZJQTZrKo8Y8AWKnuV5GT4scfuUGt9LzNoIx3dU1nQ==
-  dependencies:
-    asynckit "^0.4.0"
-    combined-stream "^1.0.8"
-    es-set-tostringtag "^2.1.0"
-    mime-types "^2.1.35"
-    safe-buffer "^5.2.1"
 
 form-data@^4.0.0:
   version "4.0.3"
@@ -6746,18 +6387,18 @@ get-stream@^6.0.0:
   resolved "https://registry.yarnpkg.com/get-stream/-/get-stream-6.0.1.tgz#a262d8eef67aced57c2852ad6167526a43cbf7b7"
   integrity sha512-ts6Wi+2j3jQjqi70w5AlN8DFnkSwC+MqmxEzdEALB2qXZYV3X/b1CTfgPLGJNMeAWxdPfU8FO1ms3NUfaHCPYg==
 
-gill@^0.10.2:
-  version "0.10.3"
-  resolved "https://registry.yarnpkg.com/gill/-/gill-0.10.3.tgz#0eeeaf18b9a6ec7adc17967f51f86be042ee2f24"
-  integrity sha512-4LIVA32lKcWoqU/dbwu+YpJbR59QQT6mvCtqkElBWF2aT9upmewjKN3/anhfTGy+o/RJykAV21i3RzCj9FR0Xg==
+gill@0.10.2:
+  version "0.10.2"
+  resolved "https://registry.yarnpkg.com/gill/-/gill-0.10.2.tgz#593c031c9964739739a07480199d0c409da40fb5"
+  integrity sha512-upWoY2dfOzKHOcX3UnD+B3h9WUunPv0oxeKzsIgKSaLyURpWK9oI+K2NHWbwrUFsXEK6ozu/sgkhuqyAcVTZCg==
   dependencies:
     "@solana-program/address-lookup-table" "^0.7.0"
     "@solana-program/compute-budget" "^0.8.0"
     "@solana-program/system" "^0.7.0"
-    "@solana-program/token-2022" "^0.4.2"
+    "@solana-program/token-2022" "^0.4.1"
     "@solana/assertions" "^2.1.1"
     "@solana/codecs" "^2.1.1"
-    "@solana/kit" "^2.3.0"
+    "@solana/kit" "^2.1.1"
     "@solana/transaction-confirmation" "^2.1.1"
 
 glob-parent@^5.1.2:
@@ -7065,11 +6706,6 @@ is-core-module@^2.16.0:
   dependencies:
     hasown "^2.0.2"
 
-is-electron@^2.2.0:
-  version "2.2.2"
-  resolved "https://registry.yarnpkg.com/is-electron/-/is-electron-2.2.2.tgz#3778902a2044d76de98036f5dc58089ac4d80bb9"
-  integrity sha512-FO/Rhvz5tuw4MCWkpMzHFKWD2LsfHzIb7i6MdPYZ/KW7AlxawyLkqdy+jPZP1WubqEADE3O4FUENlJHDfQASRg==
-
 is-extglob@^2.1.1:
   version "2.1.1"
   resolved "https://registry.yarnpkg.com/is-extglob/-/is-extglob-2.1.1.tgz#a88c02535791f02ed37c76a1b9ea9773c833f8c2"
@@ -7130,11 +6766,6 @@ is-regex@^1.2.1:
     has-tostringtag "^1.0.2"
     hasown "^2.0.2"
 
-is-stream@^1.1.0:
-  version "1.1.0"
-  resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-1.1.0.tgz#12d4a3dd4e68e0b79ceb8dbc84173ae80d91ca44"
-  integrity sha512-uQPm8kcs47jx38atAcWTVxyltQYoPT68y9aWYdV6yWXSyW8mzSat0TL6CiWdZeCdF3KrAvpVtnHbTv4RN+rqdQ==
-
 is-stream@^2.0.0:
   version "2.0.1"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.1.tgz#fac1e3d53b97ad5a9d0ae9cef2389f5810a5c077"
@@ -7152,15 +6783,15 @@ isexe@^2.0.0:
   resolved "https://registry.yarnpkg.com/isexe/-/isexe-2.0.0.tgz#e8fbf374dc556ff8947a10dcb0572d633f2cfa10"
   integrity sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==
 
+isomorphic-ws@5.0.0, isomorphic-ws@^5.0.0:
+  version "5.0.0"
+  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
+  integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
+
 isomorphic-ws@^4.0.1:
   version "4.0.1"
   resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-4.0.1.tgz#55fd4cd6c5e6491e76dc125938dd863f5cd4f2dc"
   integrity sha512-BhBvN2MBpWTaSHdWRb/bwdZJ1WaehQ2L1KngkCkfLUGF0mAWAT1sQUQacEmQ0jXkFw/czDXPNQSL5u2/Krsz1w==
-
-isomorphic-ws@^5.0.0:
-  version "5.0.0"
-  resolved "https://registry.yarnpkg.com/isomorphic-ws/-/isomorphic-ws-5.0.0.tgz#e5529148912ecb9b451b46ed44d53dae1ce04bbf"
-  integrity sha512-muId7Zzn9ywDsyXgTIafTry2sV3nySZeUDe6YedVd1Hvuuep5AsIlqK+XefWpYTyJG5e503F2xIuT2lcU6rCSw==
 
 istanbul-lib-coverage@^3.0.0, istanbul-lib-coverage@^3.2.0:
   version "3.2.2"
@@ -7612,11 +7243,6 @@ joi@^17.3.0:
     "@sideway/formula" "^3.0.1"
     "@sideway/pinpoint" "^2.0.0"
 
-js-sha256@^0.11.0:
-  version "0.11.1"
-  resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.11.1.tgz#712262e8fc9569d6f7f6eea72c0d8e5ccc7c976c"
-  integrity sha512-o6WSo/LUvY2uC4j7mO50a2ms7E/EAdbP0swigLV+nzHKTTaYnaLIWJ02VdXrsJX0vGedDESQnLsOekr94ryfjg==
-
 js-sha256@^0.9.0:
   version "0.9.0"
   resolved "https://registry.yarnpkg.com/js-sha256/-/js-sha256-0.9.0.tgz#0b89ac166583e91ef9123644bd3c5334ce9d0966"
@@ -7751,11 +7377,6 @@ locate-path@^6.0.0:
   dependencies:
     p-locate "^5.0.0"
 
-lodash.camelcase@^4.3.0:
-  version "4.3.0"
-  resolved "https://registry.yarnpkg.com/lodash.camelcase/-/lodash.camelcase-4.3.0.tgz#b28aa6288a2b9fc651035c7711f65ab6190331a6"
-  integrity sha512-TwuEnCnxbc3rAvhf/LbG7tJUDzhqXyFnv3dtzLOPgCG/hODL7WFnsbwktkD7yUV0RrreP/l1PALq/YSg6VvjlA==
-
 lodash.defaults@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/lodash.defaults/-/lodash.defaults-4.2.0.tgz#d09178716ffea4dde9e5fb7b37f6f0802274580c"
@@ -7781,7 +7402,7 @@ lodash@^4.17.15:
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
 
-logform@^2.4.0, logform@^2.7.0:
+logform@^2.7.0:
   version "2.7.0"
   resolved "https://registry.yarnpkg.com/logform/-/logform-2.7.0.tgz#cfca97528ef290f2e125a08396805002b2d060d1"
   integrity sha512-TFYA4jnP7PVbmlBIfhlSe+WKxs9dklXMTEGcBCIvLhE/Tn3H6Gk1norupVW7m5Cnd4bLcr08AytbyV/xj7f/kQ==
@@ -7792,11 +7413,6 @@ logform@^2.4.0, logform@^2.7.0:
     ms "^2.1.1"
     safe-stable-stringify "^2.3.1"
     triple-beam "^1.3.0"
-
-loglevel@^1.9.2:
-  version "1.9.2"
-  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.9.2.tgz#c2e028d6c757720107df4e64508530db6621ba08"
-  integrity sha512-HgMmCqIJSAKqo68l0rS2AanEWfkxaZ5wNiEFb5ggm08lDs9Xl2KxBlX3PTcaD2chBM1gXAYf491/M2Rv8Jwayg==
 
 long@^5.0.0:
   version "5.3.2"
@@ -7884,7 +7500,7 @@ mime-db@1.52.0:
   resolved "https://registry.yarnpkg.com/mime-db/-/mime-db-1.54.0.tgz#cddb3ee4f9c64530dff640236661d42cb6a314f5"
   integrity sha512-aU5EJuIN2WDemCcAp2vFBfp/m4EAhWJnUNSSw0ixs7/kXbd6Pg64EmwJkNdFhB8aWt1sH2CTXrLxo/iAGV3oPQ==
 
-mime-types@^2.1.12, mime-types@^2.1.35, mime-types@~2.1.24, mime-types@~2.1.34:
+mime-types@^2.1.12, mime-types@~2.1.24, mime-types@~2.1.34:
   version "2.1.35"
   resolved "https://registry.yarnpkg.com/mime-types/-/mime-types-2.1.35.tgz#381a871b62a734450660ae3deee44813f70d959a"
   integrity sha512-ZDY+bPm5zTTF+YpCrAU9nK0UgICYPT0QtT1NZWFv4s++TNkcgVaT0g6+4R2uI4MjQjzysHB1zxuWL50hzaeXiw==
@@ -8114,11 +7730,6 @@ optionator@^0.9.3:
     type-check "^0.4.0"
     word-wrap "^1.2.5"
 
-p-finally@^1.0.0:
-  version "1.0.0"
-  resolved "https://registry.yarnpkg.com/p-finally/-/p-finally-1.0.0.tgz#3fbcfb15b899a44123b34b6dcc18b724336a2cae"
-  integrity sha512-LICb2p9CB7FS+0eR1oqWnHhp0FljGLZCWBE9aix0Uye9W8LTQPwMTYVGWQWIw9RdQiDg4+epXQODwIYJtSJaow==
-
 p-limit@^2.2.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/p-limit/-/p-limit-2.3.0.tgz#3dd33c647a214fdfffd835933eb086da0dc21db1"
@@ -8146,29 +7757,6 @@ p-locate@^5.0.0:
   integrity sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw==
   dependencies:
     p-limit "^3.0.2"
-
-p-queue@^6.6.1:
-  version "6.6.2"
-  resolved "https://registry.yarnpkg.com/p-queue/-/p-queue-6.6.2.tgz#2068a9dcf8e67dd0ec3e7a2bcb76810faa85e426"
-  integrity sha512-RwFpb72c/BhQLEXIZ5K2e+AhgNVmIejGlTgiB9MzZ0e93GRvqZ7uSi0dvRF7/XIXDeNkra2fNHBxTyPDGySpjQ==
-  dependencies:
-    eventemitter3 "^4.0.4"
-    p-timeout "^3.2.0"
-
-p-retry@^4.0.0:
-  version "4.6.2"
-  resolved "https://registry.yarnpkg.com/p-retry/-/p-retry-4.6.2.tgz#9baae7184057edd4e17231cee04264106e092a16"
-  integrity sha512-312Id396EbJdvRONlngUx0NydfrIQ5lsYu0znKVUzVvArzEIt08V1qhtyESbGVd1FGX7UKtiFp5uwKZdM8wIuQ==
-  dependencies:
-    "@types/retry" "0.12.0"
-    retry "^0.13.1"
-
-p-timeout@^3.2.0:
-  version "3.2.0"
-  resolved "https://registry.yarnpkg.com/p-timeout/-/p-timeout-3.2.0.tgz#c7e17abc971d2a7962ef83626b35d635acf23dfe"
-  integrity sha512-rhIwUycgwwKcP9yTOOFK/AKsAopjjCakVqLHePO3CC6Mir1Z99xT+R63jZxAT5lFZLa2inS5h+ZS2GvR99/FBg==
-  dependencies:
-    p-finally "^1.0.0"
 
 p-try@^2.0.0:
   version "2.2.0"
@@ -8362,7 +7950,7 @@ prettier-linter-helpers@^1.0.0:
   dependencies:
     fast-diff "^1.1.2"
 
-prettier@^2.4.1, prettier@^2.5.1:
+prettier@^2.4.1:
   version "2.8.8"
   resolved "https://registry.yarnpkg.com/prettier/-/prettier-2.8.8.tgz#e8c5d7e98a4305ffe3de2e1fc4aca1a71c28b1da"
   integrity sha512-tdN8qQGvNjw4CHbY+XXk0JgCXn9QiF21a55rBe5LJAU+kDyC4WQn4+awm2Xfk2lQMk5fKup9XgzTZtGkjBdP9Q==
@@ -8389,28 +7977,10 @@ prompts@^2.0.1:
     kleur "^3.0.3"
     sisteransi "^1.0.5"
 
-protobufjs@*, protobufjs@^7.2.5, protobufjs@^7.5.3:
+protobufjs@*, protobufjs@^7.5.3:
   version "7.5.4"
   resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.4.tgz#885d31fe9c4b37f25d1bb600da30b1c5b37d286a"
   integrity sha512-CvexbZtbov6jW2eXAvLukXjXUW1TzFaivC46BpWc/3BpcCysb5Vffu+B3XHMm8lVEuy2Mm4XGex8hBSg1yapPg==
-  dependencies:
-    "@protobufjs/aspromise" "^1.1.2"
-    "@protobufjs/base64" "^1.1.2"
-    "@protobufjs/codegen" "^2.0.4"
-    "@protobufjs/eventemitter" "^1.1.0"
-    "@protobufjs/fetch" "^1.1.0"
-    "@protobufjs/float" "^1.0.2"
-    "@protobufjs/inquire" "^1.1.0"
-    "@protobufjs/path" "^1.1.2"
-    "@protobufjs/pool" "^1.1.0"
-    "@protobufjs/utf8" "^1.1.0"
-    "@types/node" ">=13.7.0"
-    long "^5.0.0"
-
-protobufjs@^7.4.0:
-  version "7.5.3"
-  resolved "https://registry.yarnpkg.com/protobufjs/-/protobufjs-7.5.3.tgz#13f95a9e3c84669995ec3652db2ac2fb00b89363"
-  integrity sha512-sildjKwVqOI2kmFDiXQ6aEB0fjYTafpEvIBs8tOR8qI4spuL9OPROLVu2qZqi/xgCfsHIwVqlaF8JBjWFHnKbw==
   dependencies:
     "@protobufjs/aspromise" "^1.1.2"
     "@protobufjs/base64" "^1.1.2"
@@ -8612,11 +8182,6 @@ ret@~0.2.0:
   resolved "https://registry.yarnpkg.com/ret/-/ret-0.2.2.tgz#b6861782a1f4762dce43402a71eb7a283f44573c"
   integrity sha512-M0b3YWQs7R3Z917WRQy1HHA7Ba7D8hvZg6UE5mLykJxQVE2ju0IXbGlaHPPlkY+WN7wFP+wUMXmBFA0aV6vYGQ==
 
-retry@^0.13.1:
-  version "0.13.1"
-  resolved "https://registry.yarnpkg.com/retry/-/retry-0.13.1.tgz#185b1587acf67919d63b357349e03537b2484658"
-  integrity sha512-XQBQ3I8W1Cge0Seh+6gjj03LbmRFWuoszgK9ooCpwYIrhhoO80pfq4cUkU5DkknwfOfFteRwlZ56PYOGYyFWdg==
-
 reusify@^1.0.4:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/reusify/-/reusify-1.1.0.tgz#0fe13b9522e1473f51b558ee796e08f11f9b489f"
@@ -8633,19 +8198,6 @@ rimraf@^3.0.2:
   integrity sha512-JZkJMZkAGFFPP2YqXZXPbMlMBgsxzE8ILs4lMIX/2o0L9UBw9O/Y3o6wFw/i9YLapcUJWwqbi3kdxIPdC62TIA==
   dependencies:
     glob "^7.1.3"
-
-rpc-websockets@7.5.1:
-  version "7.5.1"
-  resolved "https://registry.yarnpkg.com/rpc-websockets/-/rpc-websockets-7.5.1.tgz#e0a05d525a97e7efc31a0617f093a13a2e10c401"
-  integrity sha512-kGFkeTsmd37pHPMaHIgN1LVKXMi0JD782v4Ds9ZKtLlwdTKjn+CxM9A9/gLT2LaOuEcEFGL98h1QWQtlOIdW0w==
-  dependencies:
-    "@babel/runtime" "^7.17.2"
-    eventemitter3 "^4.0.7"
-    uuid "^8.3.2"
-    ws "^8.5.0"
-  optionalDependencies:
-    bufferutil "^4.0.1"
-    utf-8-validate "^5.0.2"
 
 rpc-websockets@^9.0.2:
   version "9.3.2"
@@ -8682,7 +8234,7 @@ safe-buffer@5.1.2:
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.1.2.tgz#991ec69d296e0313747d59bdfd2b745c35f8828d"
   integrity sha512-Gd2UZBJDkXlY7GbJxfsE8/nvKkUEU1G38c1siN6QP6a9PT9MmHB8GnpscSmMJSoF8LOIrt8ud/wPtojys4G6+g==
 
-safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@^5.2.1, safe-buffer@~5.2.0:
+safe-buffer@5.2.1, safe-buffer@^5.0.1, safe-buffer@~5.2.0:
   version "5.2.1"
   resolved "https://registry.yarnpkg.com/safe-buffer/-/safe-buffer-5.2.1.tgz#1eaf9fa9bdb1fdd4ec75f58f9cdb4e6b7827eec6"
   integrity sha512-rp3So07KcdmmKbGvgaNxQSJr7bGVSVk5S9Eq1F+ppbRo70+YeaDxkw5Dd8NPN+GD6bjnYm2VuPuCXmpuYvmCXQ==
@@ -8728,7 +8280,7 @@ semver@^6.3.0, semver@^6.3.1:
   resolved "https://registry.yarnpkg.com/semver/-/semver-6.3.1.tgz#556d2ef8689146e46dcea4bfdd095f3434dffcb4"
   integrity sha512-BR7VvDCVHO+q2xBEWskxS6DJE1qRnb7DxzUrogb71CWoSficBxYsiAGd+Kl0mmq/MprG9yArRkyrQxTO6XjMzA==
 
-semver@^7.3.2, semver@^7.3.5, semver@^7.3.7, semver@^7.5.3, semver@^7.5.4, semver@^7.7.2:
+semver@^7.3.2, semver@^7.3.5, semver@^7.5.3, semver@^7.5.4, semver@^7.7.2:
   version "7.7.2"
   resolved "https://registry.yarnpkg.com/semver/-/semver-7.7.2.tgz#67d99fdcd35cec21e6f8b87a7fd515a33f982b58"
   integrity sha512-RF0Fw+rO5AMf9MAyaRXI4AV0Ulj5lMHqVxxdSgiVbixSCXoEmmX/jk0CuJw4+3SqroYO9VoUh+HcuJivvtJemA==
@@ -8887,69 +8439,30 @@ socket.io-redis@^6.1.1:
     socket.io-adapter "~2.2.0"
     uid2 "0.0.3"
 
-solana-bankrun-darwin-arm64@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-arm64/-/solana-bankrun-darwin-arm64-0.3.1.tgz#65ab6cd2e74eef260c38251f4c53721cf5b9030f"
-  integrity sha512-9LWtH/3/WR9fs8Ve/srdo41mpSqVHmRqDoo69Dv1Cupi+o1zMU6HiEPUHEvH2Tn/6TDbPEDf18MYNfReLUqE6A==
-
 solana-bankrun-darwin-arm64@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-arm64/-/solana-bankrun-darwin-arm64-0.4.0.tgz#eb0f3dfffb1675f6329a1e026b12d09222b33986"
   integrity sha512-6dz78Teoz7ez/3lpRLDjktYLJb79FcmJk2me4/YaB8WiO6W43OdExU4h+d2FyuAryO2DgBPXaBoBNY/8J1HJmw==
-
-solana-bankrun-darwin-universal@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-universal/-/solana-bankrun-darwin-universal-0.3.1.tgz#bf691457cf046e8739c021ca11e48de5b4fefd45"
-  integrity sha512-muGHpVYWT7xCd8ZxEjs/bmsbMp8XBqroYGbE4lQPMDUuLvsJEIrjGqs3MbxEFr71sa58VpyvgywWd5ifI7sGIg==
 
 solana-bankrun-darwin-universal@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-universal/-/solana-bankrun-darwin-universal-0.4.0.tgz#0ac13ec7637b334b1030e6f51abecc50a254b5de"
   integrity sha512-zSSw/Jx3KNU42pPMmrEWABd0nOwGJfsj7nm9chVZ3ae7WQg3Uty0hHAkn5NSDCj3OOiN0py9Dr1l9vmRJpOOxg==
 
-solana-bankrun-darwin-x64@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-x64/-/solana-bankrun-darwin-x64-0.3.1.tgz#c6f30c0a6bc3e1621ed90ce7562f26e93bf5303f"
-  integrity sha512-oCaxfHyt7RC3ZMldrh5AbKfy4EH3YRMl8h6fSlMZpxvjQx7nK7PxlRwMeflMnVdkKKp7U8WIDak1lilIPd3/lg==
-
 solana-bankrun-darwin-x64@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/solana-bankrun-darwin-x64/-/solana-bankrun-darwin-x64-0.4.0.tgz#f863c5a668858b7c44be51376bd05fb077c11c99"
   integrity sha512-LWjs5fsgHFtyr7YdJR6r0Ho5zrtzI6CY4wvwPXr8H2m3b4pZe6RLIZjQtabCav4cguc14G0K8yQB2PTMuGub8w==
-
-solana-bankrun-linux-x64-gnu@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/solana-bankrun-linux-x64-gnu/-/solana-bankrun-linux-x64-gnu-0.3.1.tgz#78b522f1a581955a48f43a8fb560709c11301cfd"
-  integrity sha512-PfRFhr7igGFNt2Ecfdzh3li9eFPB3Xhmk0Eib17EFIB62YgNUg3ItRnQQFaf0spazFjjJLnglY1TRKTuYlgSVA==
 
 solana-bankrun-linux-x64-gnu@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/solana-bankrun-linux-x64-gnu/-/solana-bankrun-linux-x64-gnu-0.4.0.tgz#30fd7edaf3ff6585468138d3bed6eaed37878d9e"
   integrity sha512-SrlVrb82UIxt21Zr/XZFHVV/h9zd2/nP25PMpLJVLD7Pgl2yhkhfi82xj3OjxoQqWe+zkBJ+uszA0EEKr67yNw==
 
-solana-bankrun-linux-x64-musl@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/solana-bankrun-linux-x64-musl/-/solana-bankrun-linux-x64-musl-0.3.1.tgz#1a044a132138a0084e82406ec7bf4939f06bed68"
-  integrity sha512-6r8i0NuXg3CGURql8ISMIUqhE7Hx/O7MlIworK4oN08jYrP0CXdLeB/hywNn7Z8d1NXrox/NpYUgvRm2yIzAsQ==
-
 solana-bankrun-linux-x64-musl@0.4.0:
   version "0.4.0"
   resolved "https://registry.yarnpkg.com/solana-bankrun-linux-x64-musl/-/solana-bankrun-linux-x64-musl-0.4.0.tgz#3c870218140b1307dc44b51d2282697c99f2e1e4"
   integrity sha512-Nv328ZanmURdYfcLL+jwB1oMzX4ZzK57NwIcuJjGlf0XSNLq96EoaO5buEiUTo4Ls7MqqMyLbClHcrPE7/aKyA==
-
-solana-bankrun@0.3.1:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/solana-bankrun/-/solana-bankrun-0.3.1.tgz#13665ab7c1c15ec2b3354aae56980d0ded514998"
-  integrity sha512-inRwON7fBU5lPC36HdEqPeDg15FXJYcf77+o0iz9amvkUMJepcwnRwEfTNyMVpVYdgjTOBW5vg+596/3fi1kGA==
-  dependencies:
-    "@solana/web3.js" "^1.68.0"
-    bs58 "^4.0.1"
-  optionalDependencies:
-    solana-bankrun-darwin-arm64 "0.3.1"
-    solana-bankrun-darwin-universal "0.3.1"
-    solana-bankrun-darwin-x64 "0.3.1"
-    solana-bankrun-linux-x64-gnu "0.3.1"
-    solana-bankrun-linux-x64-musl "0.3.1"
 
 solana-bankrun@0.4.0:
   version "0.4.0"
@@ -8997,14 +8510,6 @@ split2@^4.0.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/split2/-/split2-4.2.0.tgz#c9c5920904d148bab0b9f67145f245a86aadbfa4"
   integrity sha512-UcjcJOWknrNkF6PLX83qcHM6KHgVKNkV62Y8a5uYDVv9ydGQVwAHMKqHdJje1VTWpljG0WYpCDhrCdAOYH4TWg==
-
-spok@^1.4.3:
-  version "1.5.5"
-  resolved "https://registry.yarnpkg.com/spok/-/spok-1.5.5.tgz#a51f7f290a53131d7b7a922dfedc461dda0aed72"
-  integrity sha512-IrJIXY54sCNFASyHPOY+jEirkiJ26JDqsGiI0Dvhwcnkl0PEWi1PSsrkYql0rzDw8LFVTcA7rdUCAJdE2HE+2Q==
-  dependencies:
-    ansicolors "~0.3.2"
-    find-process "^1.4.7"
 
 sprintf-js@~1.0.2:
   version "1.0.3"
@@ -9340,11 +8845,6 @@ undici-types@^7.11.0:
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.13.0.tgz#a20ba7c0a2be0c97bd55c308069d29d167466bff"
   integrity sha512-Ov2Rr9Sx+fRgagJ5AX0qvItZG/JKKoBRAVITs1zk7IqZGTJUwgUr7qoYBpWwakpWilTZFM98rG/AFRocu10iIQ==
 
-undici-types@~5.26.4:
-  version "5.26.5"
-  resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-5.26.5.tgz#bcd539893d00b56e964fd2657a4866b221a65617"
-  integrity sha512-JlCMO+ehdEIKqlFxk6IfVoAUVmgz7cU7zD/h9XZ0qzeosSHmUJVOzSQvvYSYWXkFXC+IfLKSIffhv0sVZup6pA==
-
 undici-types@~7.8.0:
   version "7.8.0"
   resolved "https://registry.yarnpkg.com/undici-types/-/undici-types-7.8.0.tgz#de00b85b710c54122e44fbfd911f8d70174cd294"
@@ -9472,15 +8972,7 @@ which@^2.0.1:
   dependencies:
     isexe "^2.0.0"
 
-winston-slack-webhook-transport@2.3.5:
-  version "2.3.5"
-  resolved "https://registry.yarnpkg.com/winston-slack-webhook-transport/-/winston-slack-webhook-transport-2.3.5.tgz#b460578bb09568c5e62ba186db4be873d9cee65b"
-  integrity sha512-ZlWB0QwRpch/xygDoRCucGv+1SmkL2SJyrAHzHnu8aTwq0tuFXTGG/v7VUw4h04h27CGUx1Nrq4/ykXaE+Wntw==
-  dependencies:
-    axios "^1.6.8"
-    winston-transport "^4.7.0"
-
-winston-transport@^4.7.0, winston-transport@^4.9.0:
+winston-transport@^4.9.0:
   version "4.9.0"
   resolved "https://registry.yarnpkg.com/winston-transport/-/winston-transport-4.9.0.tgz#3bba345de10297654ea6f33519424560003b3bf9"
   integrity sha512-8drMJ4rkgaPo1Me4zD/3WLfI/zPdA9o2IipKODunnGDcuqbHwjsbB79ylv04LCGGzU0xQ6vTznOMpQGaLhhm6A==
@@ -9488,23 +8980,6 @@ winston-transport@^4.7.0, winston-transport@^4.9.0:
     logform "^2.7.0"
     readable-stream "^3.6.2"
     triple-beam "^1.3.0"
-
-winston@3.13.0:
-  version "3.13.0"
-  resolved "https://registry.yarnpkg.com/winston/-/winston-3.13.0.tgz#e76c0d722f78e04838158c61adc1287201de7ce3"
-  integrity sha512-rwidmA1w3SE4j0E5MuIufFhyJPBDG7Nu71RkZor1p2+qHvJSZ9GYDA81AyleQcZbh/+V6HjeBdfnTZJm9rSeQQ==
-  dependencies:
-    "@colors/colors" "^1.6.0"
-    "@dabh/diagnostics" "^2.0.2"
-    async "^3.2.3"
-    is-stream "^2.0.0"
-    logform "^2.4.0"
-    one-time "^1.0.0"
-    readable-stream "^3.4.0"
-    safe-stable-stringify "^2.3.1"
-    stack-trace "0.0.x"
-    triple-beam "^1.3.0"
-    winston-transport "^4.7.0"
 
 winston@^3.8.1:
   version "3.17.0"
@@ -9585,17 +9060,12 @@ yallist@^3.0.2:
   resolved "https://registry.yarnpkg.com/yallist/-/yallist-3.1.1.tgz#dbb7daf9bfd8bac9ab45ebf602b8cbad0d5d08fd"
   integrity sha512-a4UGQaWPH59mOXUYnAG2ewncQS4i4F43Tv3JoAM+s2VDAmS9NsK8GpDMLrCHPksFT7h3K6TOoUNn2pb7RoXx4g==
 
-yaml@^2.6.1:
-  version "2.8.0"
-  resolved "https://registry.yarnpkg.com/yaml/-/yaml-2.8.0.tgz#15f8c9866211bdc2d3781a0890e44d4fa1a5fff6"
-  integrity sha512-4lLa/EcQCB0cJkyts+FpIRx5G/llPxfP6VQU5KByHEhLxY3IJCH0f0Hy1MHI8sClTvsIb8qwRJ6R/ZdlDJ/leQ==
-
 yargs-parser@^21.1.1:
   version "21.1.1"
   resolved "https://registry.yarnpkg.com/yargs-parser/-/yargs-parser-21.1.1.tgz#9096bceebf990d21bb31fa9516e0ede294a77d35"
   integrity sha512-tVpsJW7DdjecAiFpbIB1e3qxIQsE6NoPc5/eTdrbbIC4h0LVsWhnoa3g+m2HclBIujHzsxZ4VJVA+GUuc2/LBw==
 
-yargs@17.7.2, yargs@^17.3.1, yargs@^17.7.2:
+yargs@17.7.2, yargs@^17.3.1:
   version "17.7.2"
   resolved "https://registry.yarnpkg.com/yargs/-/yargs-17.7.2.tgz#991df39aca675a192b816e1e0363f9d75d2aa269"
   integrity sha512-7dSzzRQ++CKnNI/krKnYRV7JKKPUXMEh61soaHKg9mrWEhzFWhFnxPxGl+69cD1Ou63C13NUPCnmIcrvqCuM6w==
@@ -9617,13 +9087,6 @@ yocto-queue@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/yocto-queue/-/yocto-queue-0.1.0.tgz#0294eb3dee05028d31ee1a5fa2c556a6aaf10a1b"
   integrity sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==
-
-zod@4.0.0-beta.20250505T195954:
-  version "4.0.0-beta.20250505T195954"
-  resolved "https://registry.yarnpkg.com/zod/-/zod-4.0.0-beta.20250505T195954.tgz#ba9da025671de2dde9d4d033089f03c37a35022f"
-  integrity sha512-iB8WvxkobVIXMARvQu20fKvbS7mUTiYRpcD8OQV1xjRhxO0EEpYIRJBk6yfBzHAHEdOSDh3SxDITr5Eajr2vtg==
-  dependencies:
-    "@zod/core" "0.11.6"
 
 zod@4.0.17:
   version "4.0.17"


### PR DESCRIPTION
## Why

Migrate dlob-server off the upstream `@drift-labs/sdk` onto the velocity fork (`@velocity-exchange/sdk@0.0.3`), matching the same swap already landed in `keeper-bots-v2` and `internal-keeper-bot`.

## Approach

Yarn `resolutions` aliases `@drift-labs/sdk` → `npm:@velocity-exchange/sdk@0.0.3` so transitive deps still importing the upstream name resolve through the fork. Bulk-renames imports across `src/` and `example/`. `tsconfig.json` `paths` updated for the `common/clients` deep import.

The velocity SDK drops several features; this PR removes their consumers end-to-end rather than stubbing:

- Phoenix / Openbook / Serum fulfillment subscribers and the spot-market `phoenixMarket` / `openbookMarket` / `serumMarket` config fields (gone from `dlobPublisher`, `utils`, `priorityFeesPublisher`)
- `ProtectMakerParamsMap` and the `DLOBSubscriptionConfig.protectedMakerView` flag — `DLOBProvider.getDLOB()` loses its second arg
- `WebSocketAccountSubscriberV2` perp-account-subscriber override on the websocket subscription config
- `PerpPosition.lpShares` zero-check in the unsettled-pnl publisher (LP shares concept removed)
- `calculateBidAskPrice` lost its 4th `withUpdate` arg — drop the trailing `undefined`

## Notes

- `EventSubscriber` in `tradesPublisher.ts` casts `driftClient.program as any` — the new SDK's `Program<Drift>` vs anchor's `Program<Idl>` aren't structurally compatible for the `addEventListener` callback type. Same shape as elsewhere in the migration.
- Pre-existing tsc/lint errors in `athena/example.ts`, `athena/testRedisPolling.ts`, `scripts/pollAuctionParams.ts`, and one `prefer-const` in `utils.ts` are unrelated and left in place — they were already failing on master and the docker build only runs esbuild (no typecheck).